### PR TITLE
Add stree command documentation and fix XdebugTrace null handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,42 @@ try {
 ✅ All contexts validate successfully!
 ```
 
+## Semantic Tree Visualizer (stree)
+
+Visualize semantic log JSON files as a tree for easy analysis:
+
+```bash
+# Basic tree view (default: 2 levels deep)
+vendor/bin/stree debug.json
+
+# Show 5 levels deep
+vendor/bin/stree --depth=5 detailed.json
+
+# Expand specific context types beyond depth limit
+vendor/bin/stree --expand=DatabaseQuery log.json
+
+# Show only operations slower than 10ms
+vendor/bin/stree --threshold=10ms slow.json
+
+# Interactive HTML output
+vendor/bin/stree --format=html --full trace.json
+
+# Save HTML to file
+vendor/bin/stree --format=html trace.json > trace.html
+```
+
+### Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--depth=N` | `-d` | Maximum tree depth (default: 2) |
+| `--expand=CTX` | `-e` | Expand specific context type beyond depth limit |
+| `--threshold=T` | `-t` | Time threshold filter (e.g., `10ms`, `0.5s`) |
+| `--lines=N` | `-l` | Max lines for multi-line data (default: 5, 0 = no limit) |
+| `--format=FORMAT` | | Output format: `text` (default) or `html` |
+| `--full` | `-f` | Show complete tree without depth limits |
+| `--help` | `-h` | Display help |
+
 ## Documentation
 
 **[Schema Portal](https://koriym.github.io/Koriym.SemanticLogger/)** - AI-native semantic schema portal with comprehensive documentation

--- a/demo/e-commerce.php
+++ b/demo/e-commerce.php
@@ -17,6 +17,8 @@ use function microtime;
 use function number_format;
 use function uniqid;
 use function usleep;
+use function xdebug_start_trace;
+use function xdebug_stop_trace;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;

--- a/src/AbstractContext.php
+++ b/src/AbstractContext.php
@@ -6,9 +6,7 @@ namespace Koriym\SemanticLogger;
 
 abstract class AbstractContext
 {
-    /** @var string */
     public const TYPE = '';
 
-    /** @var string */
     public const SCHEMA_URL = '';
 }

--- a/src/Profiler/XdebugTrace.php
+++ b/src/Profiler/XdebugTrace.php
@@ -12,6 +12,7 @@ use function file_get_contents;
 use function filesize;
 use function function_exists;
 use function ini_get;
+use function is_string;
 use function rtrim;
 use function str_ends_with;
 use function sys_get_temp_dir;
@@ -84,7 +85,7 @@ final class XdebugTrace implements JsonSerializable
         $traceFile = function_exists('xdebug_get_tracefile_name') ? xdebug_get_tracefile_name() : false; // @codeCoverageIgnore
         @xdebug_stop_trace(); // @codeCoverageIgnore - suppress errors if not running
 
-        if ($traceFile === false || ! file_exists($traceFile)) {
+        if (! is_string($traceFile) || ! file_exists($traceFile)) {
             return new self(); // @codeCoverageIgnore
         }
 


### PR DESCRIPTION
## Summary

- Add `bin/stree` command documentation to README with usage examples and options table
- Fix `TypeError` in `XdebugTrace` when `xdebug_get_tracefile_name()` returns `null` (use `is_string()` instead of `=== false`)
- Apply `composer cs-fix` style corrections

## Test plan

- ✅ All 171 tests pass (`./vendor/bin/phpunit --no-coverage`)
- ✅ `composer cs-fix` applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the semantic tree visualization CLI, including command examples for controlling tree depth, filtering, and output formatting, along with a complete options reference table.

* **Bug Fixes**
  * Enhanced trace file name validation with stricter type checking before verifying file existence.

* **Chores**
  * Added explicit function imports and removed redundant docblock annotations from constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->