### PR TITLE
Add semantic-log CLI tools and fix XdebugTrace null handling

### DIFF
--- a/bin/autoload.php
+++ b/bin/autoload.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Common autoloader loader for bin scripts
+ * Loads the Composer autoloader from various possible locations
+ * Returns the best-guess project root (directory containing vendor/)
+ */
+
+// Load autoloader from possible paths
+$autoloadPaths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../autoload.php',
+    __DIR__ . '/../../../autoload.php', // When installed via composer
+];
+
+foreach ($autoloadPaths as $autoloadPath) {
+    if (file_exists($autoloadPath)) {
+        require_once $autoloadPath;
+        
+        // Return the directory containing vendor/ as project root
+        $normalized = str_replace('\\', '/', $autoloadPath);
+        return substr($normalized, -20) === '/vendor/autoload.php'
+            ? dirname($autoloadPath, 2)  // Go up from vendor/autoload.php to project root
+            : dirname($autoloadPath);    // For direct autoload.php paths
+    }
+}
+
+$searchPaths = implode("\n  ", $autoloadPaths);
+fwrite(STDERR, "Error: Composer autoloader not found. Run 'composer install' first.\nSearched paths:\n  $searchPaths\n");
+exit(1);

--- a/bin/semantic-log-explain
+++ b/bin/semantic-log-explain
@@ -1,0 +1,47 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/autoload.php';
+
+use Koriym\SemanticLogger\SemanticCli;
+
+function showUsage(): void
+{
+    echo "Usage: semantic-log-explain [index] [directory]\n\n";
+    echo "Analyze and explain semantic profile log with AI.\n\n";
+    echo "Arguments:\n";
+    echo "  index       Profile index (1=newest, 2=2nd newest, etc. Default: 1)\n";
+    echo "  directory   Target directory (default: current directory)\n\n";
+    echo "Examples:\n";
+    echo "  semantic-log-explain              # Latest profile\n";
+    echo "  semantic-log-explain 2            # 2nd newest profile\n";
+    echo "  semantic-log-explain 3 demo       # 3rd newest profile from demo dir\n";
+}
+
+// Parse command line arguments
+$index = 1;
+$directory = '.';
+
+$args = array_slice($argv, 1);
+
+if (!empty($args) && ($args[0] === 'help' || $args[0] === '--help' || $args[0] === '-h')) {
+    showUsage();
+    exit(0);
+}
+
+// Parse arguments in order: index, directory
+foreach ($args as $i => $arg) {
+    if ($i === 0 && is_numeric($arg)) {
+        $index = (int)$arg;
+    } elseif ($i === 1 || ($i === 0 && !is_numeric($arg))) {
+        $directory = $arg;
+    }
+}
+
+try {
+    $cli = new SemanticCli($directory);
+    echo $cli->explainSemanticLog($index) . "\n";
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/bin/semantic-log-list
+++ b/bin/semantic-log-list
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+require __DIR__ . '/autoload.php';
+
+use Koriym\SemanticLogger\SemanticCli;
+
+function showUsage(): void
+{
+    echo "Usage: semantic-log-list [directory]\n\n";
+    echo "List all semantic profile log files with details.\n\n";
+    echo "Arguments:\n";
+    echo "  directory   Target directory (default: current directory)\n";
+}
+
+// Parse command line arguments
+$directory = $argv[1] ?? '.';
+
+if ($directory === 'help' || $directory === '--help' || $directory === '-h') {
+    showUsage();
+    exit(0);
+}
+
+try {
+    $cli = new SemanticCli($directory);
+    echo $cli->listSemanticProfiles() . "\n";
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/bin/stree
+++ b/bin/stree
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/autoload.php';
 
 use Koriym\SemanticLogger\Stree\StreeCommand;
 

--- a/bin/validate-semantic-log.php
+++ b/bin/validate-semantic-log.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+require __DIR__ . '/autoload.php';
 
 use Koriym\SemanticLogger\SemanticLogValidator;
 

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
             "@metrics"
         ],
         "demo": [
-            "XDEBUG_MODE=profile,trace php -d zend_extension=xdebug -d extension=xhprof -d xdebug.mode=profile,trace -d xdebug.start_with_request=no -d xdebug.output_dir=/tmp -d xhprof.output_dir=/tmp -d xdebug.profiler_output_name=cachegrind.out.%H-%R-%t -d xdebug.trace_output_name=trace.%H-%R-%t -d xdebug.profiler_append=0 -d xdebug.collect_params=1 -d xdebug.collect_return=1 -d xdebug.collect_assignments=1 demo/run.php",
+            "XDEBUG_MODE=profile,trace php -d zend_extension=xdebug -d extension=xhprof -d xdebug.mode=profile,trace -d xdebug.start_with_request=no -d xdebug.output_dir=/tmp -d xhprof.output_dir=/tmp -d xdebug.profiler_output_name=cachegrind.out.%H-%R-%t -d xdebug.trace_output_name=trace.%H-%R-%t -d xdebug.profiler_append=0 -d xdebug.collect_params=1 -d xdebug.collect_return=1 -d xdebug.collect_assignments=1 -d xdebug.use_compression=0 demo/run.php",
             "php bin/validate-semantic-log.php demo/semantic-log-demo.json demo/schemas",
             "php bin/stree demo/semantic-log-demo.json"
         ],

--- a/demo/Contexts/ComplexQueryContext.php
+++ b/demo/Contexts/ComplexQueryContext.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Koriym\SemanticLogger;
 
+use Koriym\SemanticLogger\Profiler\XdebugTrace;
+use Koriym\SemanticLogger\Profiler\XHProfResult;
+
+use function usleep;
+
 final class ComplexQueryContext extends AbstractContext
 {
     public const TYPE = 'complex_query';
     public const SCHEMA_URL = 'https://example.com/schema/complex-query.json';
+
+    public readonly XHProfResult $xhprofResult;
+    public readonly XdebugTrace $xdebugTrace;
 
     public function __construct(
         public readonly string $queryType,
@@ -19,5 +27,26 @@ final class ComplexQueryContext extends AbstractContext
         public readonly bool $hasError,
         public readonly string|null $customerId = null,
     ) {
+        // 自動プロファイリング
+        $this->xhprofResult = $this->createXHProfResult();
+        $this->xdebugTrace = $this->createXdebugTrace();
+    }
+
+    private function createXHProfResult(): XHProfResult
+    {
+        $xhprof = XHProfResult::start();
+        // クエリ実行をシミュレート（実際のクエリ実行時間相当）
+        usleep((int) ($this->executionTime * 1000000));
+
+        return $xhprof->stop($this->table . '/' . $this->queryType);
+    }
+
+    private function createXdebugTrace(): XdebugTrace
+    {
+        $trace = XdebugTrace::start();
+        // クエリ実行をシミュレート
+        usleep((int) ($this->executionTime * 1000000));
+
+        return $trace->stop();
     }
 }

--- a/demo/e-commerce.php
+++ b/demo/e-commerce.php
@@ -8,7 +8,6 @@ use Throwable;
 
 use function basename;
 use function file_put_contents;
-use function function_exists;
 use function get_class;
 use function json_encode;
 use function memory_get_peak_usage;
@@ -495,22 +494,8 @@ class ComplexWebRequestSimulation
 
     public function run(): void
     {
-        // Start Xdebug trace manually
-        echo "=== Debug: Starting Xdebug trace ===\n";
-        if (function_exists('xdebug_start_trace')) {
-            $traceFile = '/Users/akihito/git/Koriym.SemanticLogger/demo/xdebug_trace.xt';
-            xdebug_start_trace($traceFile);
-            echo "Xdebug trace started: {$traceFile}.xt\n";
-        }
-
         // Only run the main e-commerce scenario - no mixed HTTP requests
         $this->simulateECommerceOrderProcessing();
-
-        // Stop Xdebug trace
-        if (function_exists('xdebug_stop_trace')) {
-            xdebug_stop_trace();
-            echo "Xdebug trace stopped\n";
-        }
 
         // Debug: Check logger state before flush
         echo "=== Debug: Logger state before flush ===\n";

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
+  <file src="src/McpServer.php">
+    <ForbiddenCode>
+      <code><![CDATA[shell_exec($command)]]></code>
+    </ForbiddenCode>
+    <MixedAssignment>
+      <code><![CDATA[$clientVersion]]></code>
+      <code><![CDATA[$decoded]]></code>
+      <code><![CDATA[$id]]></code>
+    </MixedAssignment>
+    <PossiblyFalseOperand>
+      <code><![CDATA[json_encode($logData, JSON_PRETTY_PRINT)]]></code>
+      <code><![CDATA[json_encode($response)]]></code>
+    </PossiblyFalseOperand>
+    <RiskyTruthyFalsyComparison>
+      <code><![CDATA[getenv('MCP_DEBUG')]]></code>
+    </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/SemanticCli.php">
+    <MixedAssignment>
+      <code><![CDATA[$decoded]]></code>
+    </MixedAssignment>
+  </file>
   <file src="src/SemanticProfilerMcpServer.php">
     <ForbiddenCode>
       <code><![CDATA[shell_exec($command)]]></code>

--- a/src/AbstractContext.php
+++ b/src/AbstractContext.php
@@ -6,9 +6,7 @@ namespace Koriym\SemanticLogger;
 
 abstract class AbstractContext
 {
-    /** @var string */
     public const TYPE = '';
 
-    /** @var string */
     public const SCHEMA_URL = '';
 }

--- a/src/Exception/InvalidParamsException.php
+++ b/src/Exception/InvalidParamsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Exception;
+
+use Exception;
+
+final class InvalidParamsException extends Exception
+{
+    public function getJsonRpcCode(): int
+    {
+        return -32602;
+    }
+}

--- a/src/Exception/MethodNotFoundException.php
+++ b/src/Exception/MethodNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Exception;
+
+use Exception;
+
+final class MethodNotFoundException extends Exception
+{
+    public function getJsonRpcCode(): int
+    {
+        return -32601;
+    }
+}

--- a/src/OpenCloseEntry.php
+++ b/src/OpenCloseEntry.php
@@ -16,10 +16,11 @@ final class OpenCloseEntry implements JsonSerializable
         public readonly string $schemaUrl,
         public readonly array $context,
         public readonly OpenCloseEntry|null $open = null,
+        public readonly EventEntry|null $close = null,
     ) {
     }
 
-    /** @return array{id: string, type: string, schemaUrl: string, context: array<string, mixed>, open?: array<string, mixed>} */
+    /** @return array{id: string, type: string, schemaUrl: string, context: array<string, mixed>, open?: array<string, mixed>, close?: array<string, mixed>} */
     public function toArray(): array
     {
         $result = [
@@ -31,6 +32,10 @@ final class OpenCloseEntry implements JsonSerializable
 
         if ($this->open !== null) {
             $result['open'] = $this->open->toArray();
+        }
+
+        if ($this->close !== null) {
+            $result['close'] = $this->close->toArray();
         }
 
         return $result;

--- a/src/Profiler/XdebugTrace.php
+++ b/src/Profiler/XdebugTrace.php
@@ -12,6 +12,7 @@ use function file_get_contents;
 use function filesize;
 use function function_exists;
 use function ini_get;
+use function is_string;
 use function rtrim;
 use function str_ends_with;
 use function sys_get_temp_dir;
@@ -84,7 +85,7 @@ final class XdebugTrace implements JsonSerializable
         $traceFile = function_exists('xdebug_get_tracefile_name') ? xdebug_get_tracefile_name() : false; // @codeCoverageIgnore
         @xdebug_stop_trace(); // @codeCoverageIgnore - suppress errors if not running
 
-        if ($traceFile === false || ! file_exists($traceFile)) {
+        if (! is_string($traceFile) || ! file_exists($traceFile)) {
             return new self(); // @codeCoverageIgnore
         }
 

--- a/src/SemanticCli.php
+++ b/src/SemanticCli.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use Exception;
+use InvalidArgumentException;
+
+use function basename;
+use function count;
+use function date;
+use function file_get_contents;
+use function filemtime;
+use function filesize;
+use function glob;
+use function implode;
+use function is_array;
+use function is_dir;
+use function json_decode;
+use function json_encode;
+use function number_format;
+use function rtrim;
+use function sprintf;
+use function usort;
+
+use const JSON_PRETTY_PRINT;
+
+/**
+ * Command Line Interface for Semantic Profiler
+ */
+final class SemanticCli
+{
+    public function __construct(private string $logDirectory)
+    {
+        if (! is_dir($logDirectory)) {
+            throw new InvalidArgumentException("Directory not found: $logDirectory");
+        }
+    }
+
+    public function listSemanticProfiles(): string
+    {
+        $pattern = rtrim($this->logDirectory, '/') . '/semantic-log-*.json';
+        $files = glob($pattern);
+
+        if ($files === false || empty($files)) {
+            return 'No semantic profile files found in directory: ' . $this->logDirectory;
+        }
+
+        // Sort by modification time (newest first)
+        usort($files, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        $fileList = [];
+        foreach ($files as $file) {
+            $basename = basename($file);
+            $size = filesize($file);
+            $mtime = filemtime($file);
+            if ($size === false || $mtime === false) {
+                continue;
+            }
+
+            $fileList[] = sprintf(
+                '• %s (%s bytes, %s)',
+                $basename,
+                number_format($size),
+                date('Y-m-d H:i:s', $mtime),
+            );
+        }
+
+        return "Available semantic profile files:\n\n" . implode("\n", $fileList);
+    }
+
+    public function getSemanticProfile(): string
+    {
+        return $this->explainSemanticLog(1);
+    }
+
+    public function explainSemanticLog(int $index = 1): string
+    {
+        $pattern = rtrim($this->logDirectory, '/') . '/semantic-log-*.json';
+        $files = glob($pattern);
+
+        if ($files === false || empty($files)) {
+            throw new InvalidArgumentException("No semantic log files found in directory: $this->logDirectory");
+        }
+
+        // Sort by modification time (newest first)
+        usort($files, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        if ($index < 1 || $index > count($files)) {
+            throw new InvalidArgumentException("Invalid index: $index. Available files: " . count($files));
+        }
+
+        $logFile = $files[$index - 1]; // Convert to 0-based array index
+
+        $logData = $this->getLog($logFile);
+        $analysisPrompt = $this->getAnalysisPrompt();
+
+        $jsonData = json_encode($logData, JSON_PRETTY_PRINT);
+        if ($jsonData === false) {
+            throw new Exception('Failed to encode log data as JSON');
+        }
+
+        return $analysisPrompt . "\n\n```json\n" . $jsonData . "\n```";
+    }
+
+    /** @return array<string, mixed> */
+    private function getLog(string $file): array
+    {
+        $content = file_get_contents($file);
+
+        if ($content === false) {
+            return ['error' => 'Failed to read file'];
+        }
+
+        $decoded = json_decode($content, true);
+
+        if (is_array($decoded)) {
+            /** @var array<string, mixed> $result */
+            $result = $decoded;
+
+            return $result;
+        }
+
+        return ['error' => 'Invalid log format'];
+    }
+
+    private function getAnalysisPrompt(): string
+    {
+        return <<<'PROMPT'
+This is a SEMANTIC PROFILING log - structured business logic analysis, not low-level Xdebug traces.
+
+SEMANTIC PROFILING focuses on:
+- Business workflow analysis (open → events → close patterns)
+- Application logic performance (database queries, API calls, cache operations)
+- Architectural insights and code quality assessment
+
+IGNORE low-level framework overhead and focus on YOUR APPLICATION CODE.
+
+The log contains schemaUrl fields. Refer to these schemas to understand the semantic meaning of each context:
+- business_logic: Core application operations
+- database_connection/complex_query: Data access patterns
+- external_api_request: Third-party service integrations
+- cache_operation: Caching strategy effectiveness
+- performance_metrics: Aggregated application metrics
+
+If no performance issues are found, provide:
+- What the code is doing (business purpose)
+- How it's implemented (technical approach)
+- Implementation assessment (is this approach appropriate for the task?)
+- Any architectural observations or suggestions for production readiness
+
+Use the semantic profiling data to provide deep insights about code quality and appropriateness, not just performance metrics.
+
+Please respond in the language most appropriate for this context.
+PROMPT;
+    }
+}

--- a/src/Stree/Exception/ParserException.php
+++ b/src/Stree/Exception/ParserException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Stree\Exception;
+
+use RuntimeException;
+
+final class ParserException extends RuntimeException
+{
+}


### PR DESCRIPTION
## Summary

Extracted CLI tools from PR #8, dropping MCP server components.

- Add `bin/semantic-log-list` and `bin/semantic-log-explain` with `src/SemanticCli.php`
- Add shared `bin/autoload.php` for all bin scripts
- Add `close` field serialization to `OpenCloseEntry`
- Add domain-specific exception classes (`InvalidParamsException`, `MethodNotFoundException`, `ParserException`)
- Switch `bin/stree` and `bin/validate-semantic-log.php` to use shared autoloader
- Move XHProf/Xdebug profiling into `ComplexQueryContext` (demo)
- Fix `TypeError` in `XdebugTrace` when `xdebug_get_tracefile_name()` returns `null`

## Not included (from PR #8)

- MCP server (`src/McpServer.php`, `bin/semantic-mcp.php`) — CLI is sufficient
- `GenericMcpServer.php` — accidental commit
- `demo/xdebug_trace.xt.xt.gz` — binary file

## Test plan

- ✅ All 171 tests pass
- ✅ `composer cs-fix` applied