### PR TITLE
Fix bin scripts to resolve Composer autoload when installed as dependency

### DIFF
--- a/bin/stree
+++ b/bin/stree
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+require_once $GLOBALS['_composer_autoload_path'] ?? __DIR__ . '/../vendor/autoload.php';
 
 use Koriym\SemanticLogger\Stree\StreeCommand;
 

--- a/bin/stree
+++ b/bin/stree
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+/** @psalm-suppress UnresolvableInclude */
 require_once $GLOBALS['_composer_autoload_path'] ?? __DIR__ . '/../vendor/autoload.php';
 
 use Koriym\SemanticLogger\Stree\StreeCommand;

--- a/bin/validate-semantic-log.php
+++ b/bin/validate-semantic-log.php
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+/** @psalm-suppress UnresolvableInclude */
 require_once $GLOBALS['_composer_autoload_path'] ?? dirname(__DIR__) . '/vendor/autoload.php';
 
 use Koriym\SemanticLogger\SemanticLogValidator;

--- a/bin/validate-semantic-log.php
+++ b/bin/validate-semantic-log.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once $GLOBALS['_composer_autoload_path'] ?? dirname(__DIR__) . '/vendor/autoload.php';
 
 use Koriym\SemanticLogger\SemanticLogValidator;
 


### PR DESCRIPTION
## Summary

- `bin/stree` and `bin/validate-semantic-log.php` used a hard-coded `__DIR__`-relative path to `vendor/autoload.php`
- When installed as a Composer dependency, `vendor/bin/stree` is a wrapper that sets `$GLOBALS['_composer_autoload_path']` to the root `vendor/autoload.php`
- The scripts ignored this and tried to load their own (non-existent) `vendor/autoload.php`, causing a fatal error

## Fix

Use the Composer-provided path with fallback to the standalone path:

```php
require_once $GLOBALS['_composer_autoload_path'] ?? __DIR__ . '/../vendor/autoload.php';
```

`bin/semantic-mcp` already used a multi-path fallback approach; this fix uses the Composer-standard `$GLOBALS['_composer_autoload_path']` pattern which is more direct.

## Test plan

- [ ] `composer require koriym/semantic-logger` in a host project, then run `vendor/bin/stree` — should no longer throw "Failed to open stream: vendor/autoload.php"
- [ ] Standalone usage (`php bin/stree`) still works via the fallback path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency/autoloader loading to prefer a configured global path with a safe fallback for varied deployment setups.
  * Added a static analysis hint to reduce false positives during code checks and improve bootstrap reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->