### PR TITLE
Remove -prompt.md generation from DevLogger

### DIFF
--- a/src/DevLogger.php
+++ b/src/DevLogger.php
@@ -12,7 +12,6 @@ use function file_put_contents;
 use function getmypid;
 use function json_encode;
 use function sprintf;
-use function str_replace;
 use function sys_get_temp_dir;
 use function uniqid;
 
@@ -20,12 +19,7 @@ use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const LOCK_EX;
 
-/**
- * Development logger for MCP server integration
- *
- * Handles file output of semantic logs with Profile data for AI-assisted debugging.
- * Uses single responsibility principle - only concerned with development log output.
- */
+/** Writes semantic log JSON to a file for development/debugging purposes */
 final class DevLogger
 {
     public function __construct(
@@ -39,9 +33,6 @@ final class DevLogger
         $this->logDirectory = sys_get_temp_dir();
     }
 
-    /**
-     * Output semantic logs to file for development/debugging purposes
-     */
     public function log(SemanticLoggerInterface $logger): void
     {
         try {
@@ -64,16 +55,8 @@ final class DevLogger
 
         $filename = $this->generateFilename();
         file_put_contents($filename, $jsonContent, LOCK_EX);
-
-        // Save analysis prompt alongside JSON for AI-native processing
-        $promptFilename = str_replace('.json', '-prompt.md', $filename);
-        $analysisPrompt = $this->getAnalysisPrompt() . "\n\n```json\n" . $jsonContent . "\n```";
-        file_put_contents($promptFilename, $analysisPrompt, LOCK_EX);
     }
 
-    /**
-     * Generate unique filename for concurrent request safety
-     */
     private function generateFilename(): string
     {
         $timestamp = date('Y-m-d_H-i-s-u'); // Microseconds for concurrency
@@ -89,25 +72,4 @@ final class DevLogger
         );
     }
 
-    /**
-     * Generate analysis prompt for AI-native semantic web processing
-     */
-    private function getAnalysisPrompt(): string
-    {
-        return <<<'PROMPT'
-This is a semantic profiling log. Analyze YOUR APPLICATION CODE performance, not the framework itself.
-
-The log contains schemaUrl fields. Refer to these schemas to understand the semantic meaning of the data structures.
-
-Focus on business logic within resource methods and application-specific code. Ignore framework overhead and profiling overhead.
-
-If no performance issues are found, provide:
-- What the code is doing (business purpose)
-- How it's implemented (technical approach)
-- Implementation assessment (is this approach appropriate for the task?)
-- Any architectural observations or suggestions for production readiness
-
-Use the semantic profiling data to provide deep insights about code quality and appropriateness, not just performance metrics.
-PROMPT;
-    }
 }

--- a/src/DevLogger.php
+++ b/src/DevLogger.php
@@ -71,5 +71,4 @@ final class DevLogger
             $uniqueId,
         );
     }
-
 }

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -58,14 +58,11 @@ final class DevLoggerTest extends TestCase
         // Output to file
         $this->devLogger->log($this->logger);
 
-        // Verify files were created
+        // Verify JSON file was created
         $jsonFiles = glob($this->logDirectory . '/semantic-dev-*.json');
-        $promptFiles = glob($this->logDirectory . '/semantic-dev-*-prompt.md');
 
         $this->assertIsArray($jsonFiles);
-        $this->assertIsArray($promptFiles);
         $this->assertCount(1, $jsonFiles);
-        $this->assertCount(1, $promptFiles);
     }
 
     public function testLogFileContainsValidJson(): void
@@ -90,28 +87,6 @@ final class DevLoggerTest extends TestCase
         $this->assertArrayHasKey('schemaUrl', $data);
         $this->assertArrayHasKey('open', $data);
         $this->assertArrayHasKey('close', $data);
-    }
-
-    public function testPromptFileContainsAnalysisInstructions(): void
-    {
-        // Create semantic log
-        $openId = $this->logger->open(new FakeContext('test'));
-        $this->logger->close(new FakeContext('complete'), $openId);
-
-        // Output to file
-        $this->devLogger->log($this->logger);
-
-        // Get the created prompt file
-        $promptFiles = glob($this->logDirectory . '/semantic-dev-*-prompt.md');
-        $this->assertIsArray($promptFiles);
-        $this->assertNotEmpty($promptFiles);
-
-        $content = file_get_contents($promptFiles[0]);
-        $this->assertIsString($content);
-
-        $this->assertStringContainsString('semantic profiling data', $content);
-        $this->assertStringContainsString('```json', $content);
-        $this->assertStringContainsString('APPLICATION CODE performance', $content);
     }
 
     public function testSilentFailureOnJsonEncodingError(): void
@@ -161,12 +136,6 @@ final class DevLoggerTest extends TestCase
 
         // Cleanup
         foreach ($jsonFiles as $file) {
-            unlink($file);
-        }
-
-        $promptFiles = glob($customDir . '/semantic-dev-*-prompt.md');
-        $this->assertIsArray($promptFiles);
-        foreach ($promptFiles as $file) {
             unlink($file);
         }
     }


### PR DESCRIPTION
## Summary

Remove the `-prompt.md` companion file generation from `DevLogger::saveToFile()`.

Embedding analysis prompts in log files was a prompt-engineering approach. Analysis guidance belongs in skills/tools, not in log artifacts. The `.json` file alone is sufficient — AI tools can read and interpret the structure directly.

## Changes

- Remove `getAnalysisPrompt()` method
- Remove `-prompt.md` file generation in `saveToFile()`
- Remove unused `str_replace` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal logging utilities by removing unused functionality. Public API remains unchanged; all logging features continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->