### PR TITLE
Fix stree close rendering: preserve close entries in tree output

### DIFF
--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -227,31 +227,30 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 
     private function buildNestedClose(): EventEntry
     {
-        // Convert stack to array and reverse to get correct order
+        // SplStack pops LIFO, so popping yields [outermost, ..., innermost].
+        // array_pop on that array then takes the innermost first, and we wrap
+        // outward using each parent's own fields so intermediate close entries
+        // are preserved at every level.
         $closeEntries = [];
         $stack = clone $this->closeStack;
         while (! $stack->isEmpty()) {
             $closeEntries[] = $stack->pop();
         }
 
-        $closeEntries = array_reverse($closeEntries);
-
-        // Build nested structure from outermost to innermost
         $result = array_pop($closeEntries);
 
         assert($result !== null, 'Internal error: closeStack is empty but completedOperations exist');
 
         while (! empty($closeEntries)) {
-            $child = array_pop($closeEntries);
-            // $child cannot be null since we checked ! empty($closeEntries)
-            /** @var EventEntry $child */
+            $parent = array_pop($closeEntries);
+            /** @var EventEntry $parent */
             $result = new EventEntry(
-                $result->id,
-                $result->type,
-                $result->schemaUrl,
-                $result->context,
-                $result->openId,
-                $child,
+                $parent->id,
+                $parent->type,
+                $parent->schemaUrl,
+                $parent->context,
+                $parent->openId,
+                $result,
             );
         }
 

--- a/src/Stree/LogDataParser.php
+++ b/src/Stree/LogDataParser.php
@@ -26,6 +26,13 @@ final class LogDataParser
         // Parse the hierarchical open structure
         $rootNode = $this->parseOpenEntry($openData);
 
+        // Merge close entries into their matching open nodes by openId.
+        if (array_key_exists('close', $logData) && is_array($logData['close'])) {
+            /** @var array<string, mixed> $closeData */
+            $closeData = $logData['close'];
+            $this->attachCloses($rootNode, $closeData);
+        }
+
         // Add events as leaf nodes
         if (array_key_exists('events', $logData) && is_array($logData['events'])) {
             /** @var array<string, mixed>[] $events */
@@ -34,6 +41,34 @@ final class LogDataParser
         }
 
         return $rootNode;
+    }
+
+    /** @param array<string, mixed> $closeEntry */
+    private function attachCloses(TreeNode $rootNode, array $closeEntry): void
+    {
+        /** @var mixed $rawOpenId */
+        $rawOpenId = $closeEntry['openId'] ?? null;
+        $openId = is_scalar($rawOpenId) ? (string) $rawOpenId : null;
+        $type = self::stringifyScalar($closeEntry['type'] ?? null, 'unknown');
+        /** @var mixed $context */
+        $context = $closeEntry['context'] ?? [];
+        if (! is_array($context)) {
+            $context = [];
+        }
+
+        $node = $openId !== null ? $this->findNodeById($rootNode, $openId) : null;
+        if ($node !== null) {
+            /** @var array<string, mixed> $closeCtx */
+            $closeCtx = $context;
+            $node->setClose($type, $closeCtx);
+        }
+
+        /** @var mixed $next */
+        $next = $closeEntry['close'] ?? null;
+        if (is_array($next)) {
+            /** @var array<string, mixed> $next */
+            $this->attachCloses($rootNode, $next);
+        }
     }
 
     /** @param array<string, mixed> $openEntry */
@@ -99,7 +134,6 @@ final class LogDataParser
         }
     }
 
-    /** @codeCoverageIgnore */
     private function findNodeById(TreeNode $node, string|null $id): TreeNode|null
     {
         if ($id === null) {

--- a/src/Stree/TreeNode.php
+++ b/src/Stree/TreeNode.php
@@ -21,6 +21,10 @@ final class TreeNode
     /** @var TreeNode[] */
     public array $children = [];
 
+    /** @var array<string, mixed> */
+    public array $closeContext = [];
+    public string|null $closeType = null;
+
     /** @param array<string, mixed> $context */
     public function __construct(
         public readonly string $id,
@@ -36,21 +40,44 @@ final class TreeNode
         $this->children[] = $child;
     }
 
+    /** @param array<string, mixed> $context */
+    public function setClose(string $type, array $context): void
+    {
+        $this->closeType = $type;
+        $this->closeContext = $context;
+    }
+
     public function getDisplayName(): string
     {
-        return $this->type;
+        return $this->stripOpenSuffix($this->type);
     }
 
     public function getDisplayLine(RenderConfig|null $config = null): string
     {
         $timeDisplay = $this->formatExecutionTime();
         $contextInfo = $this->extractContextInfo($config);
+        $displayType = $this->stripOpenSuffix($this->type);
 
         if ($contextInfo !== '') {
-            return sprintf('%s::%s [%s]', $this->type, $contextInfo, $timeDisplay);
+            return sprintf('%s::%s [%s]', $displayType, $contextInfo, $timeDisplay);
         }
 
-        return sprintf('%s [%s]', $this->type, $timeDisplay);
+        return sprintf('%s [%s]', $displayType, $timeDisplay);
+    }
+
+    private function stripOpenSuffix(string $type): string
+    {
+        if ($this->closeType === null) {
+            return $type;
+        }
+
+        $suffix = '_open';
+        $len = strlen($suffix);
+        if (strlen($type) > $len && substr($type, -$len) === $suffix) {
+            return substr($type, 0, -$len);
+        }
+
+        return $type;
     }
 
     private function formatExecutionTime(): string

--- a/tests/SemanticLoggerTest.php
+++ b/tests/SemanticLoggerTest.php
@@ -542,4 +542,39 @@ final class SemanticLoggerTest extends TestCase
         // Try to flush without any operations
         $this->logger->flush();
     }
+
+    public function testDeeplyNestedCloseKeepsEveryLevel(): void
+    {
+        // Regression test for buildNestedClose dropping intermediate close
+        // entries when three or more operations were stacked: the previous
+        // implementation reused $result's fields on every loop iteration, so
+        // levels between the outermost and innermost close were overwritten.
+        $ids = [];
+        for ($depth = 1; $depth <= 4; $depth++) {
+            $ids[] = $this->logger->open(new FakeContext("open {$depth}", $depth));
+        }
+
+        // Close LIFO so each level records its own context message.
+        for ($depth = 4; $depth >= 1; $depth--) {
+            $this->logger->close(new FakeContext("close {$depth}", $depth), $ids[$depth - 1]);
+        }
+
+        $logJson = $this->logger->flush();
+
+        $close = $logJson->close;
+        $this->assertSame('close 1', $close->context['message']);
+
+        $level2 = $close->close;
+        $this->assertNotNull($level2);
+        $this->assertSame('close 2', $level2->context['message']);
+
+        $level3 = $level2->close;
+        $this->assertNotNull($level3);
+        $this->assertSame('close 3', $level3->context['message']);
+
+        $level4 = $level3->close;
+        $this->assertNotNull($level4);
+        $this->assertSame('close 4', $level4->context['message']);
+        $this->assertNull($level4->close);
+    }
 }

--- a/tests/Stree/LogDataParserTest.php
+++ b/tests/Stree/LogDataParserTest.php
@@ -518,4 +518,100 @@ final class LogDataParserTest extends TestCase
         $this->assertSame('test_operation', $tree->type);
         $this->assertEmpty($tree->children); // No events should be attached
     }
+
+    public function testCloseContextIsAttachedToMatchingOpen(): void
+    {
+        $logData = [
+            'open' => [
+                'id' => 'operation_1',
+                'type' => 'process_open',
+                'schemaUrl' => 'test.json',
+                'context' => [],
+            ],
+            'close' => [
+                'id' => 'close_1',
+                'type' => 'process_close',
+                'schemaUrl' => 'test.json',
+                'context' => ['result' => 'ok'],
+                'openId' => 'operation_1',
+            ],
+            'events' => [],
+        ];
+
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData($logData);
+
+        $this->assertSame('process_close', $tree->closeType);
+        $this->assertSame(['result' => 'ok'], $tree->closeContext);
+    }
+
+    public function testNestedCloseIsMatchedToNestedOpen(): void
+    {
+        $logData = [
+            'open' => [
+                'id' => 'outer_1',
+                'type' => 'outer_open',
+                'schemaUrl' => 'test.json',
+                'context' => [],
+                'open' => [
+                    'id' => 'inner_1',
+                    'type' => 'inner_open',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
+            ],
+            'close' => [
+                'id' => 'close_outer',
+                'type' => 'outer_close',
+                'schemaUrl' => 'test.json',
+                'context' => ['outer' => true],
+                'openId' => 'outer_1',
+                'close' => [
+                    'id' => 'close_inner',
+                    'type' => 'inner_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['inner' => true],
+                    'openId' => 'inner_1',
+                ],
+            ],
+            'events' => [],
+        ];
+
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData($logData);
+
+        $this->assertSame('outer_close', $tree->closeType);
+        $this->assertSame(['outer' => true], $tree->closeContext);
+
+        $this->assertCount(1, $tree->children);
+        $inner = $tree->children[0];
+        $this->assertSame('inner_close', $inner->closeType);
+        $this->assertSame(['inner' => true], $inner->closeContext);
+    }
+
+    public function testCloseWithUnknownOpenIdIsIgnored(): void
+    {
+        $logData = [
+            'open' => [
+                'id' => 'operation_1',
+                'type' => 'process_open',
+                'schemaUrl' => 'test.json',
+                'context' => [],
+            ],
+            'close' => [
+                'id' => 'close_1',
+                'type' => 'process_close',
+                'schemaUrl' => 'test.json',
+                'context' => ['result' => 'ok'],
+                'openId' => 'does_not_exist',
+            ],
+            'events' => [],
+        ];
+
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData($logData);
+
+        $this->assertNull($tree->closeType);
+        $this->assertSame([], $tree->closeContext);
+    }
 }


### PR DESCRIPTION
## Summary

Three independent generic bug fixes that restore the close side of semantic logs in the `stree` tree renderer. Prerequisite for the larger stree redesign tracked in #15.

## Fixes

1. **`SemanticLogger::buildNestedClose()` dropped intermediate close entries in 3+ deep nested operations.** The wrap loop reused `$result->id` / `$result->type` / etc. across iterations, so each iteration overwrote the previous nest. Fixed by using the parent entry's fields when wrapping. Covered by a new 4-level nested-close test in `SemanticLoggerTest`.

2. **`LogDataParser` never attached close entries to their open nodes.** The `close` section of the log was parsed but discarded — `TreeNode` received only `open` data. Added `attachCloses()` which walks the nested close structure and pairs each entry to its `openId` via `findNodeById`. Three new tests in `LogDataParserTest` cover: direct attach, nested attach, and unknown-openId ignore.

3. **`TreeNode` now carries close metadata.** Added `closeType` / `closeContext` properties and `setClose()`. `getDisplayName()` / `getDisplayLine()` strip the `_open` suffix generically when a matching close is present.

All three are independently correct and domain-agnostic. No new match arms, no framework-specific logic.

## Test plan

- [x] `composer cs-fix` clean
- [x] `composer sa` clean
- [x] `vendor/bin/phpunit --no-coverage` — existing + 4 new tests pass
- [ ] Review close-pair handling for any edge case missed (single open with no close still renders as before)

Blocks #15 (the stree generic redesign builds on these commits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for close metadata on log entries, enabling proper closure of nested operations while preserving context information across all nesting levels throughout the logging hierarchy.

* **Bug Fixes**
  * Fixed nested close structure ordering to correctly reconstruct and preserve each level's context information during nesting composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->