### PR TITLE
Fix demo context schema violations in simple-demo and complex-demo

### DIFF
--- a/demo/complex-demo.json
+++ b/demo/complex-demo.json
@@ -11,7 +11,8 @@
                 "Content-Type": "application/json",
                 "Authorization": "Bearer eyJhbGciOiJIUzI1NiIs..."
             },
-            "responseTime": 0.580
+            "userAgent": "ECommerceApp/2.0.0",
+            "clientIp": "192.168.1.100"
         },
         "open": {
             "id": "authentication_1",
@@ -27,9 +28,23 @@
                 "type": "business_logic",
                 "schemaUrl": "./schemas/business_logic.json",
                 "context": {
-                    "operation": "process_order",
-                    "success": true,
-                    "executionTime": 0.520
+                    "operation": "order_validation",
+                    "inputData": {
+                        "customerId": 12345,
+                        "items": ["P001", "P002"],
+                        "total": 149.99
+                    },
+                    "outputData": {
+                        "orderId": "ORD_12345",
+                        "status": "confirmed"
+                    },
+                    "validationRules": {
+                        "customer_exists": true,
+                        "items_available": true,
+                        "payment_valid": true,
+                        "shipping_valid": true
+                    },
+                    "success": true
                 },
                 "open": {
                     "id": "database_connection_1",
@@ -59,6 +74,7 @@
                             "context": {
                                 "operation": "pdf_generation",
                                 "filename": "invoice_12345.pdf",
+                                "mimeType": "application/pdf",
                                 "fileSize": 245760,
                                 "processingTime": 0.095,
                                 "success": true
@@ -75,8 +91,11 @@
         "schemaUrl": "./schemas/http_response.json",
         "context": {
             "statusCode": 200,
-            "contentType": "application/json",
+            "headers": {
+                "Content-Type": "application/json"
+            },
             "contentLength": 1024,
+            "contentType": "application/json",
             "responseTime": 0.580
         },
         "openId": "http_request_1"

--- a/demo/simple-demo.json
+++ b/demo/simple-demo.json
@@ -11,16 +11,26 @@
                 "Content-Type": "application/json",
                 "Authorization": "Bearer <TOKEN_REDACTED>"
             },
-            "responseTime": 0.125
+            "userAgent": "SimpleApp/1.0.0",
+            "clientIp": "127.0.0.1"
         },
         "open": {
             "id": "business_logic_1", 
             "type": "business_logic",
             "schemaUrl": "./schemas/business_logic.json",
             "context": {
-                "operation": "create_user",
-                "success": true,
-                "executionTime": 0.095
+                "operation": "user_authentication",
+                "inputData": {
+                    "customerId": 1,
+                    "items": []
+                },
+                "outputData": {
+                    "status": "confirmed"
+                },
+                "validationRules": {
+                    "customer_exists": true
+                },
+                "success": true
             },
             "open": {
                 "id": "database_connection_1",
@@ -52,7 +62,11 @@
         "schemaUrl": "./schemas/http_response.json",
         "context": {
             "statusCode": 201,
-            "contentType": "application/json", 
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "contentLength": 256,
+            "contentType": "application/json",
             "responseTime": 0.125
         },
         "openId": "http_request_1"


### PR DESCRIPTION
Closes #19

## Summary

- **simple-demo.json**: 5 fields added (`userAgent`, `clientIp`, `inputData`, `outputData`, `validationRules`, `headers`, `contentLength`), 2 fields removed (stray `responseTime` from http_request, stray `executionTime` from business_logic); `operation` value corrected from `create_user` → `user_authentication` to match the enum
- **complex-demo.json**: 6 fields added (`userAgent`, `clientIp`, `inputData`, `outputData`, `validationRules`, `mimeType`, `headers`), 1 field removed (stray `responseTime` from http_request, stray `executionTime` from business_logic); `operation` value corrected from `process_order` → `order_validation` to match the enum
- No schemas were modified — all schemas represent the correct intended shape; `semantic-log-demo.json` is untouched

## Judgment calls

- `business_logic.operation` enums don't include `create_user` or `process_order`. Chosen replacements (`user_authentication` and `order_validation`) best match the semantic intent of each demo scenario without changing the demo narrative.
- For the "simple" demo, minimal `inputData`/`outputData`/`validationRules` were chosen (single customer, no items, basic status) to keep it representative of a simple flow while satisfying required fields.

## Test plan

- ✅ `php bin/validate-semantic-log.php demo/simple-demo.json demo/schemas/` — 0 violations
- ✅ `php bin/validate-semantic-log.php demo/complex-demo.json demo/schemas/` — 0 violations
- ✅ `php bin/validate-semantic-log.php demo/semantic-log-demo.json demo/schemas/` — 0 violations (unchanged)
- ✅ `composer cs` — no style errors
- ✅ `composer sa` — no Psalm errors
- ✅ `vendor/bin/phpunit --no-coverage` — 182 tests, 576 assertions, 0 failures