### PR TITLE
Fix #24: record real parent at open() so siblings stay siblings

### DIFF
--- a/demo/semantic-log-demo.json
+++ b/demo/semantic-log-demo.json
@@ -1,38 +1,16 @@
 {
     "$schema": "https://koriym.github.io/Koriym.SemanticLogger/schemas/combined.json",
-    "open": {
-        "id": "business_logic_1",
-        "type": "business_logic",
-        "schemaUrl": "./schemas/business_logic.json",
-        "context": {
-            "operation": "order_validation",
-            "inputData": {
-                "endpoint": "/api/orders",
-                "method": "POST",
-                "customerId": 12345
-            },
-            "outputData": [],
-            "validationRules": {
-                "customer_exists": true,
-                "items_available": true,
-                "payment_valid": true,
-                "shipping_valid": true
-            },
-            "success": false
-        },
-        "open": {
-            "id": "business_logic_2",
+    "open": [
+        {
+            "id": "business_logic_1",
             "type": "business_logic",
             "schemaUrl": "./schemas/business_logic.json",
             "context": {
                 "operation": "order_validation",
                 "inputData": {
-                    "customerId": 12345,
-                    "items": [
-                        "P001",
-                        "P045"
-                    ],
-                    "total": 209.97
+                    "endpoint": "/api/orders",
+                    "method": "POST",
+                    "customerId": 12345
                 },
                 "outputData": [],
                 "validationRules": {
@@ -43,73 +21,54 @@
                 },
                 "success": false
             },
-            "open": {
-                "id": "external_api_request_5",
-                "type": "external_api_request",
-                "schemaUrl": "./schemas/external_api_request.json",
-                "context": {
-                    "service": "EmailService",
-                    "endpoint": "https://api.sendgrid.com/v3/mail/send",
-                    "method": "POST",
-                    "statusCode": 0,
-                    "responseTime": 0,
-                    "requestSize": 2048,
-                    "responseSize": 0,
-                    "errorCode": 0
-                },
-                "open": {
-                    "id": "file_processing_1",
-                    "type": "file_processing",
-                    "schemaUrl": "./schemas/file_processing.json",
+            "open": [
+                {
+                    "id": "authentication_request_1",
+                    "type": "authentication_request",
+                    "schemaUrl": "./schemas/authentication.json",
                     "context": {
-                        "operation": "pdf_generation",
-                        "filename": "invoice_ORD_69e2d6bee9c92.pdf",
-                        "mimeType": "application/pdf",
-                        "fileSize": 0,
-                        "processingTime": 0,
-                        "success": false,
-                        "outputPath": null
-                    },
-                    "open": {
-                        "id": "external_api_request_3",
-                        "type": "external_api_request",
-                        "schemaUrl": "./schemas/external_api_request.json",
-                        "context": {
-                            "service": "ShippingService",
-                            "endpoint": "https://api.fedex.com/v1/shipments",
-                            "method": "POST",
-                            "statusCode": 0,
-                            "responseTime": 0,
-                            "requestSize": 1024,
-                            "responseSize": 0,
-                            "errorCode": 0
+                        "method": "JWT",
+                        "token": null,
+                        "requestMetadata": []
+                    }
+                },
+                {
+                    "id": "business_logic_2",
+                    "type": "business_logic",
+                    "schemaUrl": "./schemas/business_logic.json",
+                    "context": {
+                        "operation": "order_validation",
+                        "inputData": {
+                            "customerId": 12345,
+                            "items": [
+                                "P001",
+                                "P045"
+                            ],
+                            "total": 209.97
                         },
-                        "open": {
-                            "id": "external_api_request_1",
-                            "type": "external_api_request",
-                            "schemaUrl": "./schemas/external_api_request.json",
+                        "outputData": [],
+                        "validationRules": {
+                            "customer_exists": true,
+                            "items_available": true,
+                            "payment_valid": true,
+                            "shipping_valid": true
+                        },
+                        "success": false
+                    },
+                    "open": [
+                        {
+                            "id": "database_connection_1",
+                            "type": "database_connection",
+                            "schemaUrl": "./schemas/database_connection.json",
                             "context": {
-                                "service": "PaymentGateway",
-                                "endpoint": "https://api.stripe.com/v1/charges",
-                                "method": "POST",
-                                "statusCode": 0,
-                                "responseTime": 0,
-                                "requestSize": 512,
-                                "responseSize": 0,
-                                "errorCode": 0
+                                "driver": "mysql",
+                                "host": "db-cluster-1.example.com",
+                                "database": "ecommerce_prod",
+                                "connectionTime": 0.045,
+                                "pooled": true
                             },
-                            "open": {
-                                "id": "database_connection_1",
-                                "type": "database_connection",
-                                "schemaUrl": "./schemas/database_connection.json",
-                                "context": {
-                                    "driver": "mysql",
-                                    "host": "db-cluster-1.example.com",
-                                    "database": "ecommerce_prod",
-                                    "connectionTime": 0.045,
-                                    "pooled": true
-                                },
-                                "open": {
+                            "open": [
+                                {
                                     "id": "complex_query_4",
                                     "type": "complex_query",
                                     "schemaUrl": "https://example.com/schema/complex-query.json",
@@ -122,25 +81,74 @@
                                         "affectedRows": 0,
                                         "hasError": false,
                                         "customerId": null
-                                    },
-                                    "open": {
-                                        "id": "authentication_request_1",
-                                        "type": "authentication_request",
-                                        "schemaUrl": "./schemas/authentication.json",
-                                        "context": {
-                                            "method": "JWT",
-                                            "token": null,
-                                            "requestMetadata": []
-                                        }
                                     }
                                 }
+                            ]
+                        },
+                        {
+                            "id": "external_api_request_1",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "PaymentGateway",
+                                "endpoint": "https://api.stripe.com/v1/charges",
+                                "method": "POST",
+                                "statusCode": 0,
+                                "responseTime": 0,
+                                "requestSize": 512,
+                                "responseSize": 0,
+                                "errorCode": 0
+                            }
+                        },
+                        {
+                            "id": "external_api_request_3",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "ShippingService",
+                                "endpoint": "https://api.fedex.com/v1/shipments",
+                                "method": "POST",
+                                "statusCode": 0,
+                                "responseTime": 0,
+                                "requestSize": 1024,
+                                "responseSize": 0,
+                                "errorCode": 0
+                            }
+                        },
+                        {
+                            "id": "file_processing_1",
+                            "type": "file_processing",
+                            "schemaUrl": "./schemas/file_processing.json",
+                            "context": {
+                                "operation": "pdf_generation",
+                                "filename": "invoice_ORD_69e634e37dd0c.pdf",
+                                "mimeType": "application/pdf",
+                                "fileSize": 0,
+                                "processingTime": 0,
+                                "success": false,
+                                "outputPath": null
+                            }
+                        },
+                        {
+                            "id": "external_api_request_5",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "EmailService",
+                                "endpoint": "https://api.sendgrid.com/v3/mail/send",
+                                "method": "POST",
+                                "statusCode": 0,
+                                "responseTime": 0,
+                                "requestSize": 2048,
+                                "responseSize": 0,
+                                "errorCode": 0
                             }
                         }
-                    }
+                    ]
                 }
-            }
+            ]
         }
-    },
+    ],
     "events": [
         {
             "id": "http_request_1",
@@ -153,7 +161,7 @@
                     "Content-Type": "application/json",
                     "Authorization": "Bearer <TOKEN_REDACTED>",
                     "User-Agent": "ECommerceApp/2.1.0",
-                    "X-Request-ID": "req_69e2d6be94d5e"
+                    "X-Request-ID": "req_69e634e32a113"
                 },
                 "body": {
                     "customerId": 12345,
@@ -291,9 +299,9 @@
             "type": "performance_metrics",
             "schemaUrl": "./schemas/performance_metrics.json",
             "context": {
-                "executionTime": 0.4947969913482666,
-                "memoryUsed": 47784,
-                "peakMemory": 2074640,
+                "executionTime": 0.5016701221466064,
+                "memoryUsed": 52280,
+                "peakMemory": 1995368,
                 "databaseQueries": 5,
                 "totalQueryTime": 0.093,
                 "cacheHits": 2,
@@ -327,55 +335,184 @@
                 "statusCode": 201,
                 "headers": {
                     "Content-Type": "application/json",
-                    "X-Response-Time": "495.61ms",
-                    "X-Request-ID": "req_69e2d6bf199b0"
+                    "X-Response-Time": "502.30ms",
+                    "X-Request-ID": "req_69e634e3a490e"
                 },
                 "contentLength": 512,
                 "contentType": "application/json",
-                "responseTime": 0.4956088066101074,
+                "responseTime": 0.5023040771484375,
                 "cached": false
             },
             "openId": "business_logic_1"
         }
     ],
-    "close": {
-        "id": "business_logic_4",
-        "type": "business_logic",
-        "schemaUrl": "./schemas/business_logic.json",
-        "context": {
-            "operation": "order_validation",
-            "inputData": {
-                "endpoint": "/api/orders",
-                "method": "POST",
-                "customerId": 12345
-            },
-            "outputData": {
-                "orderId": "ORD_67890",
-                "status": "confirmed",
-                "responseCode": 201
-            },
-            "validationRules": {
-                "customer_exists": true,
-                "items_available": true,
-                "payment_valid": true,
-                "shipping_valid": true
-            },
-            "success": true
-        },
-        "openId": "business_logic_1",
-        "close": {
-            "id": "authentication_request_2",
-            "type": "authentication_request",
-            "schemaUrl": "./schemas/authentication.json",
+    "close": [
+        {
+            "id": "business_logic_4",
+            "type": "business_logic",
+            "schemaUrl": "./schemas/business_logic.json",
             "context": {
-                "method": "JWT",
-                "token": "user_12345",
-                "requestMetadata": {
-                    "role": "customer",
-                    "premium": true
-                }
+                "operation": "order_validation",
+                "inputData": {
+                    "endpoint": "/api/orders",
+                    "method": "POST",
+                    "customerId": 12345
+                },
+                "outputData": {
+                    "orderId": "ORD_67890",
+                    "status": "confirmed",
+                    "responseCode": 201
+                },
+                "validationRules": {
+                    "customer_exists": true,
+                    "items_available": true,
+                    "payment_valid": true,
+                    "shipping_valid": true
+                },
+                "success": true
             },
-            "openId": "authentication_request_1"
+            "openId": "business_logic_1",
+            "close": [
+                {
+                    "id": "authentication_request_2",
+                    "type": "authentication_request",
+                    "schemaUrl": "./schemas/authentication.json",
+                    "context": {
+                        "method": "JWT",
+                        "token": "user_12345",
+                        "requestMetadata": {
+                            "role": "customer",
+                            "premium": true
+                        }
+                    },
+                    "openId": "authentication_request_1"
+                },
+                {
+                    "id": "business_logic_3",
+                    "type": "business_logic",
+                    "schemaUrl": "./schemas/business_logic.json",
+                    "context": {
+                        "operation": "order_validation",
+                        "inputData": {
+                            "customerId": 12345,
+                            "items": [
+                                "P001",
+                                "P045"
+                            ],
+                            "total": 209.97
+                        },
+                        "outputData": {
+                            "orderId": "ORD_67890",
+                            "status": "confirmed",
+                            "estimatedDelivery": "2025-08-12"
+                        },
+                        "validationRules": {
+                            "customer_exists": true,
+                            "items_available": true,
+                            "payment_valid": true,
+                            "shipping_valid": true
+                        },
+                        "success": true
+                    },
+                    "openId": "business_logic_2",
+                    "close": [
+                        {
+                            "id": "database_connection_2",
+                            "type": "database_connection",
+                            "schemaUrl": "./schemas/database_connection.json",
+                            "context": {
+                                "driver": "mysql",
+                                "host": "db-cluster-1.example.com",
+                                "database": "ecommerce_prod",
+                                "connectionTime": 0.045,
+                                "pooled": true
+                            },
+                            "openId": "database_connection_1",
+                            "close": [
+                                {
+                                    "id": "complex_query_6",
+                                    "type": "complex_query",
+                                    "schemaUrl": "https://example.com/schema/complex-query.json",
+                                    "context": {
+                                        "queryType": "INSERT",
+                                        "table": "orders",
+                                        "parameters": [],
+                                        "fieldCount": 8,
+                                        "executionTime": 0.042,
+                                        "affectedRows": 1,
+                                        "hasError": false,
+                                        "customerId": null
+                                    },
+                                    "openId": "complex_query_4"
+                                }
+                            ]
+                        },
+                        {
+                            "id": "external_api_request_2",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "PaymentGateway",
+                                "endpoint": "https://api.stripe.com/v1/charges",
+                                "method": "POST",
+                                "statusCode": 200,
+                                "responseTime": 0.182,
+                                "requestSize": 512,
+                                "responseSize": 256,
+                                "errorCode": 0
+                            },
+                            "openId": "external_api_request_1"
+                        },
+                        {
+                            "id": "external_api_request_4",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "ShippingService",
+                                "endpoint": "https://api.fedex.com/v1/shipments",
+                                "method": "POST",
+                                "statusCode": 201,
+                                "responseTime": 0.098,
+                                "requestSize": 1024,
+                                "responseSize": 2048,
+                                "errorCode": 0
+                            },
+                            "openId": "external_api_request_3"
+                        },
+                        {
+                            "id": "file_processing_2",
+                            "type": "file_processing",
+                            "schemaUrl": "./schemas/file_processing.json",
+                            "context": {
+                                "operation": "pdf_generation",
+                                "filename": "invoice_ORD_67890.pdf",
+                                "mimeType": "application/pdf",
+                                "fileSize": 15360,
+                                "processingTime": 0.078,
+                                "success": true,
+                                "outputPath": "/tmp/invoices/invoice_ORD_67890.pdf"
+                            },
+                            "openId": "file_processing_1"
+                        },
+                        {
+                            "id": "external_api_request_6",
+                            "type": "external_api_request",
+                            "schemaUrl": "./schemas/external_api_request.json",
+                            "context": {
+                                "service": "EmailService",
+                                "endpoint": "https://api.sendgrid.com/v3/mail/send",
+                                "method": "POST",
+                                "statusCode": 202,
+                                "responseTime": 0.067,
+                                "requestSize": 2048,
+                                "responseSize": 128,
+                                "errorCode": 0
+                            },
+                            "openId": "external_api_request_5"
+                        }
+                    ]
+                }
+            ]
         }
-    }
+    ]
 }

--- a/docs/schemas/semantic-log.json
+++ b/docs/schemas/semantic-log.json
@@ -23,65 +23,14 @@
       "$ref": "#/definitions/schemaUrl"
     },
     "open": {
-      "type": "object",
-      "description": "Application-defined open context - type and schema determined by application needs",
-      "required": ["id", "type", "schemaUrl"],
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/operationId"
-        },
-        "type": {
-          "type": "string",
-          "description": "Application-defined context type (e.g., http_request, database_query, business_logic)"
-        },
-        "schemaUrl": {
-          "$ref": "#/definitions/schemaUrl"
-        },
-        "context": {
-          "type": "object",
-          "description": "Application-specific context data conforming to the referenced schema",
-          "additionalProperties": true
-        },
-        "open": {
-          "$ref": "#/properties/open",
-          "description": "Nested child operation within this operation - enables hierarchical operation tracking"
-        }
-      },
-      "additionalProperties": true
+      "type": "array",
+      "description": "Top-level open operations in chronological order. Each entry may carry its own nested children.",
+      "items": { "$ref": "#/definitions/openEntry" }
     },
     "close": {
-      "type": "object",
-      "description": "Application-defined close context - type and schema determined by application needs",
-      "required": ["id", "type", "schemaUrl", "openId"],
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/operationId"
-        },
-        "type": {
-          "type": "string",
-          "description": "Application-defined context type (e.g., http_response, database_result, business_complete)"
-        },
-        "schemaUrl": {
-          "$ref": "#/definitions/schemaUrl"
-        },
-        "openId": {
-          "$ref": "#/definitions/openIdReference"
-        },
-        "context": {
-          "type": "object",
-          "description": "Application-specific context data conforming to the referenced schema",
-          "additionalProperties": true
-        },
-        "profile": {
-          "$ref": "#/definitions/operationProfile",
-          "description": "Profile data attributed to this specific operation (wall time plus per-segment Xdebug/XHProf captures). Present when DevSemanticLogger produced the log."
-        },
-        "close": {
-          "$ref": "#/properties/close",
-          "description": "Nested child operation completion within this close - enables hierarchical close tracking"
-        }
-      },
-      "additionalProperties": true
+      "type": "array",
+      "description": "Top-level close operations, parallel in shape to `open`.",
+      "items": { "$ref": "#/definitions/closeEntry" }
     },
     "events": {
       "type": "array",
@@ -155,6 +104,59 @@
   },
   "additionalProperties": false,
   "definitions": {
+    "openEntry": {
+      "type": "object",
+      "description": "Application-defined open context with optional sibling children.",
+      "required": ["id", "type", "schemaUrl"],
+      "properties": {
+        "id": { "$ref": "#/definitions/operationId" },
+        "type": {
+          "type": "string",
+          "description": "Application-defined context type (e.g., http_request, database_query, business_logic)"
+        },
+        "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
+        "context": {
+          "type": "object",
+          "description": "Application-specific context data conforming to the referenced schema",
+          "additionalProperties": true
+        },
+        "open": {
+          "type": "array",
+          "description": "Nested child operations in chronological order.",
+          "items": { "$ref": "#/definitions/openEntry" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "closeEntry": {
+      "type": "object",
+      "description": "Application-defined close context; mirrors an openEntry and carries child closes in parallel.",
+      "required": ["id", "type", "schemaUrl", "openId"],
+      "properties": {
+        "id": { "$ref": "#/definitions/operationId" },
+        "type": {
+          "type": "string",
+          "description": "Application-defined context type (e.g., http_response, database_result, business_complete)"
+        },
+        "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
+        "openId": { "$ref": "#/definitions/openIdReference" },
+        "context": {
+          "type": "object",
+          "description": "Application-specific context data conforming to the referenced schema",
+          "additionalProperties": true
+        },
+        "profile": {
+          "$ref": "#/definitions/operationProfile",
+          "description": "Profile data attributed to this specific operation (wall time plus per-segment Xdebug/XHProf captures). Present when DevSemanticLogger produced the log."
+        },
+        "close": {
+          "type": "array",
+          "description": "Nested child closes in the order their opens closed.",
+          "items": { "$ref": "#/definitions/closeEntry" }
+        }
+      },
+      "additionalProperties": true
+    },
     "operationId": {
       "type": "string",
       "pattern": "^[a-z_]+_[0-9]+$",

--- a/src/DevSemanticLogger.php
+++ b/src/DevSemanticLogger.php
@@ -109,7 +109,7 @@ final class DevSemanticLogger implements SemanticLoggerInterface
                 );
             }
 
-            $closeWithProfile = $this->attachProfilesToCloseChain($logJson->close, $operations);
+            $closeWithProfile = $this->attachProfilesToCloses($logJson->close, $operations);
 
             return new LogJson(
                 $logJson->schemaUrl,
@@ -142,24 +142,30 @@ final class DevSemanticLogger implements SemanticLoggerInterface
     }
 
     /**
-     * Walk the close chain and, at each level, attach the matching OperationProfile
+     * Walk the close tree and, at each node, attach the matching OperationProfile
      * directly to that close entry so each being carries its own profile data.
      *
+     * @param list<EventEntry>                $closes
      * @param array<string, OperationProfile> $operations
+     *
+     * @return list<EventEntry>
      */
-    private function attachProfilesToCloseChain(EventEntry $close, array $operations): EventEntry
+    private function attachProfilesToCloses(array $closes, array $operations): array
     {
-        $nestedClose = $close->close !== null
-            ? $this->attachProfilesToCloseChain($close->close, $operations)
-            : null;
+        $result = [];
+        foreach ($closes as $close) {
+            $withNested = $close->withClose($this->attachProfilesToCloses($close->close, $operations));
 
-        $withNested = $close->close === $nestedClose ? $close : $close->withClose($nestedClose);
+            if ($close->openId !== null && isset($operations[$close->openId])) {
+                $result[] = $withNested->withProfile($operations[$close->openId]);
 
-        if ($close->openId !== null && isset($operations[$close->openId])) {
-            return $withNested->withProfile($operations[$close->openId]);
+                continue;
+            }
+
+            $result[] = $withNested;
         }
 
-        return $withNested;
+        return $result;
     }
 
     private function startNewSegment(): void

--- a/src/EventEntry.php
+++ b/src/EventEntry.php
@@ -8,16 +8,21 @@ use JsonSerializable;
 use Koriym\SemanticLogger\Profiler\OperationProfile;
 use Override;
 
+use function array_map;
+
 final class EventEntry implements JsonSerializable
 {
-    /** @param array<string, mixed> $context */
+    /**
+     * @param array<string, mixed> $context
+     * @param list<EventEntry>     $close   Child closes (zero or more) — immediate nested close entries in the order their opens closed.
+     */
     public function __construct(
         public readonly string $id,
         public readonly string $type,
         public readonly string $schemaUrl,
         public readonly array $context,
         public readonly string|null $openId = null,
-        public readonly EventEntry|null $close = null,
+        public readonly array $close = [],
         public readonly OperationProfile|null $profile = null,
     ) {
     }
@@ -35,7 +40,8 @@ final class EventEntry implements JsonSerializable
         );
     }
 
-    public function withClose(EventEntry|null $close): self
+    /** @param list<EventEntry> $close */
+    public function withClose(array $close): self
     {
         return new self(
             $this->id,
@@ -66,8 +72,8 @@ final class EventEntry implements JsonSerializable
             $result['profile'] = $this->profile->jsonSerialize();
         }
 
-        if ($this->close !== null) {
-            $result['close'] = $this->close->toArray();
+        if ($this->close !== []) {
+            $result['close'] = array_map(static fn (EventEntry $e) => $e->toArray(), $this->close);
         }
 
         return $result;

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -12,16 +12,16 @@ use function array_map;
 final class LogJson implements JsonSerializable
 {
     /**
+     * @param list<OpenCloseEntry>                                                  $open   Top-level opens (one or more) in chronological order.
+     * @param list<EventEntry>                                                      $close  Top-level closes (parallel to $open).
      * @param list<EventEntry>                                                      $events
      * @param list<array{rel: string, href: string, title?: string, type?: string}> $links
      */
     public function __construct(
         public readonly string $schemaUrl,
-        public readonly OpenCloseEntry $open,
-        public readonly EventEntry $close,
-        /** @var list<EventEntry> */
+        public readonly array $open,
+        public readonly array $close,
         public readonly array $events = [],
-        /** @var list<array{rel: string, href: string, title?: string, type?: string}> */
         public readonly array $links = [],
     ) {
     }
@@ -38,14 +38,14 @@ final class LogJson implements JsonSerializable
     {
         $result = [
             '$schema' => $this->schemaUrl,
-            'open' => $this->open->toArray(),
+            'open' => array_map(static fn (OpenCloseEntry $e) => $e->toArray(), $this->open),
         ];
 
         if (! empty($this->events)) {
             $result['events'] = array_map(static fn (EventEntry $event) => $event->toArray(), $this->events);
         }
 
-        $result['close'] = $this->close->toArray();
+        $result['close'] = array_map(static fn (EventEntry $e) => $e->toArray(), $this->close);
 
         if (! empty($this->links)) {
             $result['links'] = $this->links;

--- a/src/OpenCloseEntry.php
+++ b/src/OpenCloseEntry.php
@@ -7,20 +7,25 @@ namespace Koriym\SemanticLogger;
 use JsonSerializable;
 use Override;
 
+use function array_map;
+
 final class OpenCloseEntry implements JsonSerializable
 {
-    /** @param array<string, mixed> $context */
+    /**
+     * @param array<string, mixed> $context
+     * @param list<OpenCloseEntry> $open    Child opens (zero or more) — immediate nested operations in chronological order.
+     */
     public function __construct(
         public readonly string $id,
         public readonly string $type,
         public readonly string $schemaUrl,
         public readonly array $context,
-        public readonly OpenCloseEntry|null $open = null,
-        public readonly EventEntry|null $close = null,
+        public readonly array $open = [],
+        public readonly string|null $parentId = null,
     ) {
     }
 
-    /** @return array{id: string, type: string, schemaUrl: string, context: array<string, mixed>, open?: array<string, mixed>, close?: array<string, mixed>} */
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         $result = [
@@ -30,12 +35,8 @@ final class OpenCloseEntry implements JsonSerializable
             'context' => $this->context,
         ];
 
-        if ($this->open !== null) {
-            $result['open'] = $this->open->toArray();
-        }
-
-        if ($this->close !== null) {
-            $result['close'] = $this->close->toArray();
+        if ($this->open !== []) {
+            $result['open'] = array_map(static fn (OpenCloseEntry $e) => $e->toArray(), $this->open);
         }
 
         return $result;

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -12,8 +12,6 @@ use Koriym\SemanticLogger\Exception\UnclosedLogicException;
 use Override;
 use SplStack;
 
-use function array_pop;
-use function array_reverse;
 use function assert;
 use function is_array;
 use function is_string;
@@ -28,10 +26,10 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     /** @var SplStack<OpenCloseEntry> */
     private SplStack $openStack;
 
-    /** @var SplStack<EventEntry> */
-    private SplStack $closeStack;
+    /** @var list<EventEntry> Close entries in chronological close order. */
+    private array $closeLog = [];
 
-    /** @var array<OpenCloseEntry> */
+    /** @var list<OpenCloseEntry> Completed opens in chronological close order; each carries the parentId captured at open time. */
     private array $completedOperations = [];
 
     /** @var array<string, int> */
@@ -42,9 +40,6 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         /** @var SplStack<OpenCloseEntry> $openStack */
         $openStack = new SplStack();
         $this->openStack = $openStack;
-        /** @var SplStack<EventEntry> $closeStack */
-        $closeStack = new SplStack();
-        $this->closeStack = $closeStack;
     }
 
     #[Override]
@@ -58,12 +53,16 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         $schemaUrl = $context::SCHEMA_URL;
         assert(is_string($schemaUrl));
 
+        $parentId = $this->openStack->isEmpty() ? null : $this->openStack->top()->id;
+
         $contextArray = $this->contextToArray($context);
         $this->openStack->push(new OpenCloseEntry(
             $operationId,
             $type,
             $schemaUrl,
             $contextArray,
+            [],
+            $parentId,
         ));
 
         return $operationId;
@@ -118,13 +117,13 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         assert(is_string($schemaUrl));
 
         $contextArray = $this->contextToArray($context);
-        $this->closeStack->push(new EventEntry(
+        $this->closeLog[] = new EventEntry(
             $closeId,
             $type,
             $schemaUrl,
             $contextArray,
             $openId,
-        ));
+        );
     }
 
     #[Override]
@@ -171,9 +170,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         /** @var SplStack<OpenCloseEntry> $openStack */
         $openStack = new SplStack();
         $this->openStack = $openStack;
-        /** @var SplStack<EventEntry> $closeStack */
-        $closeStack = new SplStack();
-        $this->closeStack = $closeStack;
+        $this->closeLog = [];
         $this->completedOperations = [];
         $this->events = [];
         $this->typeCounts = [];
@@ -202,60 +199,114 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         return $stack->top();
     }
 
-    private function buildNestedOpen(): OpenCloseEntry
+    /**
+     * Build the open tree from real parent-child links captured at open() time.
+     *
+     * Each completed operation carries its own parentId; children are grouped
+     * under their parent and appear in chronological close order (which equals
+     * open order for correctly-nested LIFO sessions).
+     *
+     * @return list<OpenCloseEntry>
+     */
+    private function buildNestedOpen(): array
     {
-        // Rebuild the nested structure from completed operations
-        $operations = array_reverse($this->completedOperations);
-        $result = array_pop($operations);
+        $childrenByParent = $this->groupByParent();
 
-        if ($result === null) {
-            throw new NoLogSessionException('no completed operations');
+        return $this->buildOpenChildren(null, $childrenByParent);
+    }
+
+    /**
+     * @param array<string, list<OpenCloseEntry>> $childrenByParent
+     *
+     * @return list<OpenCloseEntry>
+     */
+    private function buildOpenChildren(string|null $parentId, array $childrenByParent): array
+    {
+        $key = $parentId ?? '';
+        if (! isset($childrenByParent[$key])) {
+            return [];
         }
 
-        while (! empty($operations)) {
-            $parent = array_pop($operations);
-            $result = new OpenCloseEntry(
-                $parent->id,
-                $parent->type,
-                $parent->schemaUrl,
-                $parent->context,
-                $result,
+        $result = [];
+        foreach ($childrenByParent[$key] as $op) {
+            $result[] = new OpenCloseEntry(
+                $op->id,
+                $op->type,
+                $op->schemaUrl,
+                $op->context,
+                $this->buildOpenChildren($op->id, $childrenByParent),
+                $op->parentId,
             );
         }
 
         return $result;
     }
 
-    private function buildNestedClose(): EventEntry
+    /**
+     * Build the close tree that mirrors the open tree's shape but carries close contexts.
+     *
+     * Each close is paired to its open via openId; child-close ordering follows
+     * the open tree exactly so the two trees stay structurally parallel.
+     *
+     * @return list<EventEntry>
+     */
+    private function buildNestedClose(): array
     {
-        // SplStack pops LIFO, so popping yields [outermost, ..., innermost].
-        // array_pop on that array then takes the innermost first, and we wrap
-        // outward using each parent's own fields so intermediate close entries
-        // are preserved at every level.
-        $closeEntries = [];
-        $stack = clone $this->closeStack;
-        while (! $stack->isEmpty()) {
-            $closeEntries[] = $stack->pop();
+        $childrenByParent = $this->groupByParent();
+        $closeByOpenId = [];
+        foreach ($this->closeLog as $close) {
+            if ($close->openId !== null) {
+                $closeByOpenId[$close->openId] = $close;
+            }
         }
 
-        $result = array_pop($closeEntries);
+        return $this->buildCloseChildren(null, $childrenByParent, $closeByOpenId);
+    }
 
-        assert($result !== null, 'Internal error: closeStack is empty but completedOperations exist');
+    /**
+     * @param array<string, list<OpenCloseEntry>> $childrenByParent
+     * @param array<string, EventEntry>           $closeByOpenId
+     *
+     * @return list<EventEntry>
+     */
+    private function buildCloseChildren(string|null $parentId, array $childrenByParent, array $closeByOpenId): array
+    {
+        $key = $parentId ?? '';
+        if (! isset($childrenByParent[$key])) {
+            return [];
+        }
 
-        while (! empty($closeEntries)) {
-            $parent = array_pop($closeEntries);
-            /** @var EventEntry $parent */
-            $result = new EventEntry(
-                $parent->id,
-                $parent->type,
-                $parent->schemaUrl,
-                $parent->context,
-                $parent->openId,
-                $result,
+        $result = [];
+        foreach ($childrenByParent[$key] as $op) {
+            $close = $closeByOpenId[$op->id] ?? null;
+            if ($close === null) {
+                continue;
+            }
+
+            $result[] = new EventEntry(
+                $close->id,
+                $close->type,
+                $close->schemaUrl,
+                $close->context,
+                $close->openId,
+                $this->buildCloseChildren($op->id, $childrenByParent, $closeByOpenId),
+                $close->profile,
             );
         }
 
         return $result;
+    }
+
+    /** @return array<string, list<OpenCloseEntry>> */
+    private function groupByParent(): array
+    {
+        $childrenByParent = [];
+        foreach ($this->completedOperations as $op) {
+            $key = $op->parentId ?? '';
+            $childrenByParent[$key][] = $op;
+        }
+
+        return $childrenByParent;
     }
 
     /**

--- a/src/Stree/LogDataParser.php
+++ b/src/Stree/LogDataParser.php
@@ -7,6 +7,7 @@ namespace Koriym\SemanticLogger\Stree;
 use RuntimeException;
 
 use function array_key_exists;
+use function count;
 use function is_array;
 use function is_numeric;
 use function is_scalar;
@@ -20,17 +21,25 @@ final class LogDataParser
             throw new RuntimeException('Invalid log data: missing open section');
         }
 
-        /** @var array<string, mixed> $openData */
-        $openData = $logData['open'];
+        /** @var list<array<string, mixed>> $openList */
+        $openList = $logData['open'];
+        if ($openList === []) {
+            throw new RuntimeException('Invalid log data: open section is empty');
+        }
 
-        // Parse the hierarchical open structure
-        $rootNode = $this->parseOpenEntry($openData);
+        if (count($openList) !== 1) {
+            throw new RuntimeException('stree rendering expects a single root open entry; wrap sibling roots in a parent span.');
+        }
+
+        $rootNode = $this->parseOpenEntry($openList[0]);
 
         // Merge close entries into their matching open nodes by openId.
         if (array_key_exists('close', $logData) && is_array($logData['close'])) {
-            /** @var array<string, mixed> $closeData */
-            $closeData = $logData['close'];
-            $this->attachCloses($rootNode, $closeData);
+            /** @var list<array<string, mixed>> $closeList */
+            $closeList = $logData['close'];
+            foreach ($closeList as $closeEntry) {
+                $this->attachSingleClose($rootNode, $closeEntry);
+            }
         }
 
         // Add events as leaf nodes
@@ -44,7 +53,7 @@ final class LogDataParser
     }
 
     /** @param array<string, mixed> $closeEntry */
-    private function attachCloses(TreeNode $rootNode, array $closeEntry): void
+    private function attachSingleClose(TreeNode $rootNode, array $closeEntry): void
     {
         /** @var mixed $rawOpenId */
         $rawOpenId = $closeEntry['openId'] ?? null;
@@ -63,11 +72,12 @@ final class LogDataParser
             $node->setClose($type, $closeCtx);
         }
 
-        /** @var mixed $next */
-        $next = $closeEntry['close'] ?? null;
-        if (is_array($next)) {
-            /** @var array<string, mixed> $next */
-            $this->attachCloses($rootNode, $next);
+        if (array_key_exists('close', $closeEntry) && is_array($closeEntry['close'])) {
+            /** @var list<array<string, mixed>> $nested */
+            $nested = $closeEntry['close'];
+            foreach ($nested as $child) {
+                $this->attachSingleClose($rootNode, $child);
+            }
         }
     }
 
@@ -89,12 +99,13 @@ final class LogDataParser
 
         $node = new TreeNode($id, $type, $context, $executionTime, $parent);
 
-        // Check for nested open entries
+        // Walk nested sibling children (list shape).
         if (array_key_exists('open', $openEntry) && is_array($openEntry['open'])) {
-            /** @var array<string, mixed> $nestedOpen */
-            $nestedOpen = $openEntry['open'];
-            $childNode = $this->parseOpenEntry($nestedOpen, $node);
-            $node->addChild($childNode);
+            /** @var list<array<string, mixed>> $children */
+            $children = $openEntry['open'];
+            foreach ($children as $childEntry) {
+                $node->addChild($this->parseOpenEntry($childEntry, $node));
+            }
         }
 
         return $node;

--- a/tests/DevSemanticLoggerTest.php
+++ b/tests/DevSemanticLoggerTest.php
@@ -8,8 +8,6 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 
-use function assert;
-
 final class DevSemanticLoggerTest extends TestCase
 {
     private DevSemanticLogger $logger;
@@ -26,9 +24,11 @@ final class DevSemanticLoggerTest extends TestCase
 
         $logJson = $this->logger->flush();
 
-        $this->assertNotNull($logJson->close->profile);
-        $this->assertSame($openId, $logJson->close->openId);
-        $this->assertGreaterThanOrEqual(0.0, $logJson->close->profile->wallTime);
+        $this->assertCount(1, $logJson->close);
+        $close = $logJson->close[0];
+        $this->assertNotNull($close->profile);
+        $this->assertSame($openId, $close->openId);
+        $this->assertGreaterThanOrEqual(0.0, $close->profile->wallTime);
     }
 
     public function testNestedClosesEachCarryTheirOwnProfile(): void
@@ -40,9 +40,10 @@ final class DevSemanticLoggerTest extends TestCase
 
         $logJson = $this->logger->flush();
 
-        $outerClose = $logJson->close;
-        $innerClose = $outerClose->close;
-        assert($innerClose !== null);
+        $this->assertCount(1, $logJson->close);
+        $outerClose = $logJson->close[0];
+        $this->assertCount(1, $outerClose->close);
+        $innerClose = $outerClose->close[0];
 
         $this->assertSame($outer, $outerClose->openId);
         $this->assertSame($inner, $innerClose->openId);
@@ -72,7 +73,9 @@ final class DevSemanticLoggerTest extends TestCase
 
         $this->assertArrayNotHasKey('profile', $array, 'top-level profile must not exist');
         $this->assertArrayHasKey('close', $array);
-        $close = $array['close'];
+        $closeList = $array['close'];
+        $this->assertIsArray($closeList);
+        $close = $closeList[0];
         $this->assertIsArray($close);
         $this->assertArrayHasKey('profile', $close);
         $profile = $close['profile'];
@@ -104,10 +107,10 @@ final class DevSemanticLoggerTest extends TestCase
         $second = $this->logger->flush();
 
         // Each flush produces exactly one operation, and its close carries profile.
-        $this->assertNotNull($first->close->profile);
-        $this->assertNotNull($second->close->profile);
-        $this->assertSame($id1, $first->close->openId);
-        $this->assertSame($id2, $second->close->openId);
+        $this->assertNotNull($first->close[0]->profile);
+        $this->assertNotNull($second->close[0]->profile);
+        $this->assertSame($id1, $first->close[0]->openId);
+        $this->assertSame($id2, $second->close[0]->openId);
     }
 
     public function testDevStateIsResetEvenWhenInnerFlushThrows(): void

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -70,9 +70,9 @@ final class ErrorHandlingTest extends TestCase
         $this->assertSame('https://koriym.github.io/Koriym.SemanticLogger/schemas/combined.json', $logJson->schemaUrl);
 
         // Test nested structure
-        $this->assertSame('outer', $logJson->open->context['message']);
-        $this->assertNotNull($logJson->open->open);
-        $this->assertSame('inner', $logJson->open->open->context['message']);
+        $this->assertSame('outer', $logJson->open[0]->context['message']);
+        $this->assertCount(1, $logJson->open[0]->open);
+        $this->assertSame('inner', $logJson->open[0]->open[0]->context['message']);
 
         // Test events
         $this->assertCount(2, $logJson->events);
@@ -80,7 +80,7 @@ final class ErrorHandlingTest extends TestCase
         $this->assertSame('event2', $logJson->events[1]->context['message']);
 
         // Test close (should be outer close since it's the root operation)
-        $this->assertSame('outer_finished', $logJson->close->context['message']);
+        $this->assertSame('outer_finished', $logJson->close[0]->context['message']);
 
         // Test that logger is cleared after flush
         $this->expectException(NoLogSessionException::class);

--- a/tests/LogSessionTest.php
+++ b/tests/LogSessionTest.php
@@ -11,20 +11,21 @@ final class LogSessionTest extends TestCase
     public function testLogSessionWithMinimalData(): void
     {
         $open = new OpenCloseEntry('test_1', 'test', 'https://example.com/test.json', ['data' => 'value']);
-        $close = new EventEntry('close_1', 'close', 'https://example.com/close.json', ['result' => 'success']);
+        $close = new EventEntry('close_1', 'close', 'https://example.com/close.json', ['result' => 'success'], 'test_1');
         $session = new LogJson(
             'https://schema.example.com/log.json',
-            $open,
-            $close,
+            [$open],
+            [$close],
             [],
         );
 
         $this->assertSame('https://schema.example.com/log.json', $session->schemaUrl);
-        // title removed in new API
-        $this->assertSame('test_1', $session->open->id);
-        $this->assertSame('test', $session->open->type);
+        $this->assertCount(1, $session->open);
+        $this->assertSame('test_1', $session->open[0]->id);
+        $this->assertSame('test', $session->open[0]->type);
         $this->assertEmpty($session->events);
-        $this->assertSame('close_1', $session->close->id);
+        $this->assertCount(1, $session->close);
+        $this->assertSame('close_1', $session->close[0]->id);
 
         // Test array serialization
         $array = $session->toArray();
@@ -39,25 +40,24 @@ final class LogSessionTest extends TestCase
             new EventEntry('event1_1', 'event1', 'https://example.com/event1.json', ['event' => 1]),
             new EventEntry('event2_1', 'event2', 'https://example.com/event2.json', ['event' => 2]),
         ];
-        $close = new EventEntry('end_1', 'end', 'https://example.com/end.json', ['end' => true]);
+        $close = new EventEntry('end_1', 'end', 'https://example.com/end.json', ['end' => true], 'start_1');
 
         $session = new LogJson(
             'https://schema.example.com/complete.json',
-            $open,
-            $close,
+            [$open],
+            [$close],
             $events,
         );
 
         $this->assertSame('https://schema.example.com/complete.json', $session->schemaUrl);
-        // title removed in new API
-        $this->assertSame('start_1', $session->open->id);
-        $this->assertSame('start', $session->open->type);
+        $this->assertSame('start_1', $session->open[0]->id);
+        $this->assertSame('start', $session->open[0]->type);
         $this->assertCount(2, $session->events);
         $this->assertSame('event1_1', $session->events[0]->id);
         $this->assertSame('event1', $session->events[0]->type);
         $this->assertSame('event2_1', $session->events[1]->id);
         $this->assertSame('event2', $session->events[1]->type);
-        $this->assertSame('end_1', $session->close->id);
-        $this->assertSame('end', $session->close->type);
+        $this->assertSame('end_1', $session->close[0]->id);
+        $this->assertSame('end', $session->close[0]->type);
     }
 }

--- a/tests/OpenCloseEntryTest.php
+++ b/tests/OpenCloseEntryTest.php
@@ -22,9 +22,10 @@ final class OpenCloseEntryTest extends TestCase
         $this->assertSame('https://example.com/simple.json', $entry->schemaUrl);
         $this->assertSame('hello', $entry->context['message']);
         $this->assertSame(42, $entry->context['value']);
-        $this->assertNull($entry->open);
+        $this->assertSame([], $entry->open);
+        $this->assertNull($entry->parentId);
 
-        // Test array serialization - open is null, so no 'open' key should be added
+        // Test array serialization - open is empty, so no 'open' key should be added
         $array = $entry->toArray();
         $this->assertArrayNotHasKey('open', $array);
         $this->assertSame([
@@ -35,13 +36,24 @@ final class OpenCloseEntryTest extends TestCase
         ], $array);
     }
 
-    public function testOpenCloseEntryWithNesting(): void
+    public function testOpenCloseEntryWithSiblingChildren(): void
     {
-        $nested = new OpenCloseEntry(
-            'nested_entry_1',
-            'nested_entry',
-            'https://example.com/nested.json',
-            ['nested' => true],
+        $child1 = new OpenCloseEntry(
+            'child_1',
+            'child_entry',
+            'https://example.com/child.json',
+            ['which' => 1],
+            [],
+            'parent_entry_1',
+        );
+
+        $child2 = new OpenCloseEntry(
+            'child_2',
+            'child_entry',
+            'https://example.com/child.json',
+            ['which' => 2],
+            [],
+            'parent_entry_1',
         );
 
         $entry = new OpenCloseEntry(
@@ -49,64 +61,50 @@ final class OpenCloseEntryTest extends TestCase
             'parent_entry',
             'https://example.com/parent.json',
             ['parent' => true],
-            $nested,
+            [$child1, $child2],
         );
 
-        $this->assertSame('parent_entry_1', $entry->id);
-        $this->assertSame('parent_entry', $entry->type);
-        $this->assertSame('https://example.com/parent.json', $entry->schemaUrl);
-        $this->assertSame(true, $entry->context['parent']);
+        $this->assertCount(2, $entry->open);
+        $this->assertSame('child_1', $entry->open[0]->id);
+        $this->assertSame('child_2', $entry->open[1]->id);
+        $this->assertSame('parent_entry_1', $entry->open[0]->parentId);
 
-        $this->assertNotNull($entry->open);
-        $this->assertSame('nested_entry_1', $entry->open->id);
-        $this->assertSame('nested_entry', $entry->open->type);
-        $this->assertSame('https://example.com/nested.json', $entry->open->schemaUrl);
-        $this->assertSame(true, $entry->open->context['nested']);
-
-        // Test array serialization - open is not null, so 'open' key should be added
         $array = $entry->toArray();
         $this->assertArrayHasKey('open', $array);
-        if (isset($array['open'])) {
-            /** @var array<string, mixed> $openArray */
-            $openArray = $array['open'];
-            $this->assertSame('nested_entry_1', $openArray['id']);
-            $this->assertSame('nested_entry', $openArray['type']);
-        }
+        $openArray = $array['open'];
+        $this->assertIsArray($openArray);
+        $this->assertCount(2, $openArray);
     }
 
     public function testDeepNesting(): void
     {
         $level3 = new OpenCloseEntry('level3_1', 'level3', 'https://example.com/3.json', ['level' => 3]);
-        $level2 = new OpenCloseEntry('level2_1', 'level2', 'https://example.com/2.json', ['level' => 2], $level3);
-        $level1 = new OpenCloseEntry('level1_1', 'level1', 'https://example.com/1.json', ['level' => 1], $level2);
+        $level2 = new OpenCloseEntry('level2_1', 'level2', 'https://example.com/2.json', ['level' => 2], [$level3]);
+        $level1 = new OpenCloseEntry('level1_1', 'level1', 'https://example.com/1.json', ['level' => 1], [$level2]);
 
         $this->assertSame('level1_1', $level1->id);
         $this->assertSame('level1', $level1->type);
         $this->assertSame(1, $level1->context['level']);
 
-        $this->assertNotNull($level1->open);
-        $this->assertSame('level2_1', $level1->open->id);
-        $this->assertSame('level2', $level1->open->type);
-        $this->assertSame(2, $level1->open->context['level']);
+        $this->assertCount(1, $level1->open);
+        $this->assertSame('level2_1', $level1->open[0]->id);
+        $this->assertSame(2, $level1->open[0]->context['level']);
 
-        $this->assertNotNull($level1->open->open);
-        $this->assertSame('level3_1', $level1->open->open->id);
-        $this->assertSame('level3', $level1->open->open->type);
-        $this->assertSame(3, $level1->open->open->context['level']);
-        $this->assertNull($level1->open->open->open);
+        $this->assertCount(1, $level1->open[0]->open);
+        $this->assertSame('level3_1', $level1->open[0]->open[0]->id);
+        $this->assertSame(3, $level1->open[0]->open[0]->context['level']);
+        $this->assertSame([], $level1->open[0]->open[0]->open);
 
         // Test array serialization - level3 should not have nested open
         $array = $level1->toArray();
         $this->assertArrayHasKey('open', $array);
-        if (isset($array['open'])) {
-            /** @var array<string, mixed> $level2Array */
-            $level2Array = $array['open'];
-            $this->assertArrayHasKey('open', $level2Array);
-            if (isset($level2Array['open'])) {
-                /** @var array<string, mixed> $level3Array */
-                $level3Array = $level2Array['open'];
-                $this->assertArrayNotHasKey('open', $level3Array);
-            }
-        }
+        /** @var list<array<string, mixed>> $level2List */
+        $level2List = $array['open'];
+        $level2Array = $level2List[0];
+        $this->assertArrayHasKey('open', $level2Array);
+        /** @var list<array<string, mixed>> $level3List */
+        $level3List = $level2Array['open'];
+        $level3Array = $level3List[0];
+        $this->assertArrayNotHasKey('open', $level3Array);
     }
 }

--- a/tests/SemanticLoggerTest.php
+++ b/tests/SemanticLoggerTest.php
@@ -65,11 +65,12 @@ final class SemanticLoggerTest extends TestCase
         $this->assertSame('https://koriym.github.io/Koriym.SemanticLogger/schemas/combined.json', $logJson->schemaUrl);
 
         // Open - check ID
-        $this->assertSame('process_start_1', $logJson->open->id);
-        $this->assertSame('process_start', $logJson->open->type);
-        $this->assertSame('https://example.com/schemas/process_start.json', $logJson->open->schemaUrl);
-        $this->assertSame('starting process', $logJson->open->context['message']);
-        $this->assertSame(1, $logJson->open->context['id']);
+        $this->assertCount(1, $logJson->open);
+        $this->assertSame('process_start_1', $logJson->open[0]->id);
+        $this->assertSame('process_start', $logJson->open[0]->type);
+        $this->assertSame('https://example.com/schemas/process_start.json', $logJson->open[0]->schemaUrl);
+        $this->assertSame('starting process', $logJson->open[0]->context['message']);
+        $this->assertSame(1, $logJson->open[0]->context['id']);
 
         // Events - check ID
         $this->assertCount(1, $logJson->events);
@@ -80,10 +81,64 @@ final class SemanticLoggerTest extends TestCase
         $this->assertSame(42, $logJson->events[0]->context['value']);
 
         // Close - check ID
-        $this->assertSame('process_complete_1', $logJson->close->id);
-        $this->assertSame('process_complete', $logJson->close->type);
-        $this->assertSame('https://example.com/schemas/process_complete.json', $logJson->close->schemaUrl);
-        $this->assertSame('completed successfully', $logJson->close->context['result']);
+        $this->assertCount(1, $logJson->close);
+        $this->assertSame('process_complete_1', $logJson->close[0]->id);
+        $this->assertSame('process_complete', $logJson->close[0]->type);
+        $this->assertSame('https://example.com/schemas/process_complete.json', $logJson->close[0]->schemaUrl);
+        $this->assertSame('completed successfully', $logJson->close[0]->context['result']);
+    }
+
+    public function testSequentialSiblingsAreRecordedAsSiblings(): void
+    {
+        // open_1, close_1, open_2, close_2 at the top level — sequential siblings.
+        // Regression for #24: buildNestedOpen() previously reconstructed a fake
+        // nesting from close order alone, wrapping open_2 around open_1.
+        $first = $this->logger->open(new FakeContext('first', 1));
+        $this->logger->close(new FakeContext('first done', 2), $first);
+
+        $second = $this->logger->open(new FakeContext('second', 3));
+        $this->logger->close(new FakeContext('second done', 4), $second);
+
+        $logJson = $this->logger->flush();
+
+        $this->assertCount(2, $logJson->open, 'top-level opens should be siblings, not nested');
+        $this->assertSame($first, $logJson->open[0]->id);
+        $this->assertSame('first', $logJson->open[0]->context['message']);
+        $this->assertSame([], $logJson->open[0]->open);
+
+        $this->assertSame($second, $logJson->open[1]->id);
+        $this->assertSame('second', $logJson->open[1]->context['message']);
+        $this->assertSame([], $logJson->open[1]->open);
+
+        $this->assertCount(2, $logJson->close);
+        $this->assertSame($first, $logJson->close[0]->openId);
+        $this->assertSame($second, $logJson->close[1]->openId);
+    }
+
+    public function testOuterWithTwoSiblingInnersKeepsRealOrder(): void
+    {
+        // outer { inner_1; inner_2 } — one parent containing two sibling children,
+        // which is exactly the Be Framework metamorphosis-chain shape once the
+        // chain wrapper lands on the framework side.
+        $outer = $this->logger->open(new FakeContext('outer', 1));
+
+        $inner1 = $this->logger->open(new FakeContext('inner1', 2));
+        $this->logger->close(new FakeContext('inner1 done', 3), $inner1);
+
+        $inner2 = $this->logger->open(new FakeContext('inner2', 4));
+        $this->logger->close(new FakeContext('inner2 done', 5), $inner2);
+
+        $this->logger->close(new FakeContext('outer done', 6), $outer);
+
+        $logJson = $this->logger->flush();
+
+        $this->assertCount(1, $logJson->open);
+        $root = $logJson->open[0];
+        $this->assertSame($outer, $root->id);
+
+        $this->assertCount(2, $root->open, 'outer should list both inners as siblings in order');
+        $this->assertSame($inner1, $root->open[0]->id);
+        $this->assertSame($inner2, $root->open[1]->id);
     }
 
     public function testNestedOpen(): void
@@ -107,12 +162,12 @@ final class SemanticLoggerTest extends TestCase
         $logJson = $this->logger->flush();
 
         // Root operation
-        $this->assertSame('example_event', $logJson->open->type);
-        $this->assertSame('outer process', $logJson->open->context['message']);
+        $this->assertSame('example_event', $logJson->open[0]->type);
+        $this->assertSame('outer process', $logJson->open[0]->context['message']);
 
         // Close should be the root operation close
-        $this->assertSame('example_event', $logJson->close->type);
-        $this->assertSame('outer finished', $logJson->close->context['message']);
+        $this->assertSame('example_event', $logJson->close[0]->type);
+        $this->assertSame('outer finished', $logJson->close[0]->context['message']);
     }
 
     public function testJsonSerializableOutput(): void
@@ -146,7 +201,7 @@ final class SemanticLoggerTest extends TestCase
         $logJson = $this->logger->flush();
 
         // Verify open operation has expected ID
-        $this->assertSame($openId, $logJson->open->id);
+        $this->assertSame($openId, $logJson->open[0]->id);
 
         // Verify event has openId correlation
         $this->assertCount(1, $logJson->events);
@@ -157,7 +212,7 @@ final class SemanticLoggerTest extends TestCase
         }
 
         // Verify close has openId correlation
-        $closeArray = $logJson->close->toArray();
+        $closeArray = $logJson->close[0]->toArray();
         $this->assertArrayHasKey('openId', $closeArray);
         if (isset($closeArray['openId'])) {
             $this->assertSame($openId, $closeArray['openId']);
@@ -185,9 +240,9 @@ final class SemanticLoggerTest extends TestCase
         $logJson = $this->logger->flush();
 
         // Verify parent and child IDs
-        $this->assertSame($parentId, $logJson->open->id);
-        $this->assertNotNull($logJson->open->open);
-        $this->assertSame($childId, $logJson->open->open->id);
+        $this->assertSame($parentId, $logJson->open[0]->id);
+        $this->assertCount(1, $logJson->open[0]->open);
+        $this->assertSame($childId, $logJson->open[0]->open[0]->id);
 
         // Event should be correlated with child operation
         $this->assertCount(1, $logJson->events);
@@ -198,7 +253,7 @@ final class SemanticLoggerTest extends TestCase
         }
 
         // Close entries should have correct openId correlation
-        $closeArray = $logJson->close->toArray();
+        $closeArray = $logJson->close[0]->toArray();
         $this->assertArrayHasKey('openId', $closeArray);
         if (isset($closeArray['openId'])) {
             $this->assertSame($parentId, $closeArray['openId']);
@@ -207,8 +262,9 @@ final class SemanticLoggerTest extends TestCase
         // Nested close should have child openId
         $this->assertArrayHasKey('close', $closeArray);
         if (isset($closeArray['close'])) {
-            /** @var array<string, mixed> $nestedCloseArray */
-            $nestedCloseArray = $closeArray['close'];
+            /** @var list<array<string, mixed>> $nestedCloseList */
+            $nestedCloseList = $closeArray['close'];
+            $nestedCloseArray = $nestedCloseList[0];
             $this->assertArrayHasKey('openId', $nestedCloseArray);
             if (isset($nestedCloseArray['openId'])) {
                 $this->assertSame($childId, $nestedCloseArray['openId']);
@@ -275,17 +331,17 @@ final class SemanticLoggerTest extends TestCase
         $this->assertStringContainsString('schemas/combined.json', $logJson->schemaUrl);
 
         // Verify open structure
-        $this->assertSame('example_event_1', $logJson->open->id);
-        $this->assertSame('example_event', $logJson->open->type);
-        $this->assertSame('test message', $logJson->open->context['message']);
-        $this->assertSame(123, $logJson->open->context['value']);
+        $this->assertSame('example_event_1', $logJson->open[0]->id);
+        $this->assertSame('example_event', $logJson->open[0]->type);
+        $this->assertSame('test message', $logJson->open[0]->context['message']);
+        $this->assertSame(123, $logJson->open[0]->context['value']);
 
         // Verify close structure
-        $this->assertSame('example_event_2', $logJson->close->id);
-        $this->assertSame('example_event', $logJson->close->type);
-        $this->assertSame('test complete', $logJson->close->context['message']);
-        $this->assertSame(456, $logJson->close->context['value']);
-        $this->assertSame('example_event_1', $logJson->close->openId);
+        $this->assertSame('example_event_2', $logJson->close[0]->id);
+        $this->assertSame('example_event', $logJson->close[0]->type);
+        $this->assertSame('test complete', $logJson->close[0]->context['message']);
+        $this->assertSame(456, $logJson->close[0]->context['value']);
+        $this->assertSame('example_event_1', $logJson->close[0]->openId);
 
         // Verify JSON serialization quality
         $actualJson = json_encode($logJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
@@ -310,28 +366,28 @@ final class SemanticLoggerTest extends TestCase
         $this->assertStringContainsString('schemas/combined.json', $logJson->schemaUrl);
 
         // Verify outer open
-        $this->assertSame('example_event_1', $logJson->open->id);
-        $this->assertSame('outer task', $logJson->open->context['message']);
-        $this->assertSame(100, $logJson->open->context['value']);
+        $this->assertSame('example_event_1', $logJson->open[0]->id);
+        $this->assertSame('outer task', $logJson->open[0]->context['message']);
+        $this->assertSame(100, $logJson->open[0]->context['value']);
 
         // Verify inner open (nested)
-        $this->assertNotNull($logJson->open->open);
-        $this->assertSame('example_event_2', $logJson->open->open->id);
-        $this->assertSame('inner task', $logJson->open->open->context['message']);
-        $this->assertSame(200, $logJson->open->open->context['value']);
+        $this->assertCount(1, $logJson->open[0]->open);
+        $this->assertSame('example_event_2', $logJson->open[0]->open[0]->id);
+        $this->assertSame('inner task', $logJson->open[0]->open[0]->context['message']);
+        $this->assertSame(200, $logJson->open[0]->open[0]->context['value']);
 
         // Verify outer close
-        $this->assertSame('example_event_4', $logJson->close->id);
-        $this->assertSame('outer done', $logJson->close->context['message']);
-        $this->assertSame(400, $logJson->close->context['value']);
-        $this->assertSame('example_event_1', $logJson->close->openId);
+        $this->assertSame('example_event_4', $logJson->close[0]->id);
+        $this->assertSame('outer done', $logJson->close[0]->context['message']);
+        $this->assertSame(400, $logJson->close[0]->context['value']);
+        $this->assertSame('example_event_1', $logJson->close[0]->openId);
 
         // Verify inner close (nested)
-        $this->assertNotNull($logJson->close->close);
-        $this->assertSame('example_event_3', $logJson->close->close->id);
-        $this->assertSame('inner done', $logJson->close->close->context['message']);
-        $this->assertSame(300, $logJson->close->close->context['value']);
-        $this->assertSame('example_event_2', $logJson->close->close->openId);
+        $this->assertCount(1, $logJson->close[0]->close);
+        $this->assertSame('example_event_3', $logJson->close[0]->close[0]->id);
+        $this->assertSame('inner done', $logJson->close[0]->close[0]->context['message']);
+        $this->assertSame(300, $logJson->close[0]->close[0]->context['value']);
+        $this->assertSame('example_event_2', $logJson->close[0]->close[0]->openId);
 
         // Verify JSON serialization quality
         $actualJson = json_encode($logJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
@@ -561,20 +617,21 @@ final class SemanticLoggerTest extends TestCase
 
         $logJson = $this->logger->flush();
 
-        $close = $logJson->close;
+        $this->assertCount(1, $logJson->close);
+        $close = $logJson->close[0];
         $this->assertSame('close 1', $close->context['message']);
 
-        $level2 = $close->close;
-        $this->assertNotNull($level2);
+        $this->assertCount(1, $close->close);
+        $level2 = $close->close[0];
         $this->assertSame('close 2', $level2->context['message']);
 
-        $level3 = $level2->close;
-        $this->assertNotNull($level3);
+        $this->assertCount(1, $level2->close);
+        $level3 = $level2->close[0];
         $this->assertSame('close 3', $level3->context['message']);
 
-        $level4 = $level3->close;
-        $this->assertNotNull($level4);
+        $this->assertCount(1, $level3->close);
+        $level4 = $level3->close[0];
         $this->assertSame('close 4', $level4->context['message']);
-        $this->assertNull($level4->close);
+        $this->assertSame([], $level4->close);
     }
 }

--- a/tests/Stree/LogDataParserTest.php
+++ b/tests/Stree/LogDataParserTest.php
@@ -15,16 +15,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'test_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.005],
+                [
+                    'id' => 'test_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['executionTime' => 0.005],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -42,22 +46,28 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'parent_1',
-                'type' => 'parent_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'open' => [
-                    'id' => 'child_1',
-                    'type' => 'child_operation',
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent_operation',
                     'schemaUrl' => 'test.json',
-                    'context' => ['responseTime' => 0.010],
+                    'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'child_1',
+                            'type' => 'child_operation',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['responseTime' => 0.010],
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -75,20 +85,85 @@ final class LogDataParserTest extends TestCase
         $this->assertSame(0.010, $child->executionTime);
     }
 
+    public function testParseSiblingChildren(): void
+    {
+        $logData = [
+            'open' => [
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'sib_1',
+                            'type' => 'first',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                        ],
+                        [
+                            'id' => 'sib_2',
+                            'type' => 'second',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                        ],
+                    ],
+                ],
+            ],
+            'close' => [
+                [
+                    'id' => 'close_parent',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'parent_1',
+                ],
+            ],
+            'events' => [],
+        ];
+
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData($logData);
+
+        $this->assertCount(2, $tree->children);
+        $this->assertSame('first', $tree->children[0]->type);
+        $this->assertSame('second', $tree->children[1]->type);
+    }
+
+    public function testMultipleRootsThrowForStreeRendering(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('single root open entry');
+
+        $parser = new LogDataParser();
+        $parser->parseLogData([
+            'open' => [
+                ['id' => 'a_1', 'type' => 'a', 'schemaUrl' => 'a.json', 'context' => []],
+                ['id' => 'b_1', 'type' => 'b', 'schemaUrl' => 'b.json', 'context' => []],
+            ],
+            'close' => [],
+            'events' => [],
+        ]);
+    }
+
     public function testParseEventsData(): void
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -117,16 +192,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -177,16 +256,20 @@ final class LogDataParserTest extends TestCase
 
             $logData = [
                 'open' => [
-                    'id' => 'test_1',
-                    'type' => 'test_operation',
-                    'schemaUrl' => 'test.json',
-                    'context' => $testCase,
+                    [
+                        'id' => 'test_1',
+                        'type' => 'test_operation',
+                        'schemaUrl' => 'test.json',
+                        'context' => $testCase,
+                    ],
                 ],
                 'close' => [
-                    'id' => 'close_1',
-                    'type' => 'close',
-                    'schemaUrl' => 'test.json',
-                    'context' => [],
+                    [
+                        'id' => 'close_1',
+                        'type' => 'close',
+                        'schemaUrl' => 'test.json',
+                        'context' => [],
+                    ],
                 ],
                 'events' => [],
             ];
@@ -235,16 +318,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -268,16 +355,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -302,16 +393,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 'invalid_event_string', // Non-array event should be skipped
@@ -338,16 +433,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -372,16 +471,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => 'invalid_context', // Non-array context should be converted to empty array
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => 'invalid_context', // Non-array context should be converted to empty array
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -396,12 +499,14 @@ final class LogDataParserTest extends TestCase
     public function testOpenEntryWithMissingFields(): void
     {
         $logData = [
-            'open' => ['schemaUrl' => 'test.json'], // Missing id, type - should use defaults
+            'open' => [['schemaUrl' => 'test.json']], // Missing id, type - should use defaults
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -417,16 +522,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -449,16 +558,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'test_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 'not_a_number'], // Non-numeric should result in 0.0
+                [
+                    'id' => 'test_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['executionTime' => 'not_a_number'], // Non-numeric should result in 0.0
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -473,16 +586,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             // No events section
         ];
@@ -498,16 +615,20 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => 'not_an_array', // Invalid events section
         ];
@@ -523,17 +644,21 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'process_open',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'process_open',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'process_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['result' => 'ok'],
-                'openId' => 'operation_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'process_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['result' => 'ok'],
+                    'openId' => 'operation_1',
+                ],
             ],
             'events' => [],
         ];
@@ -549,29 +674,37 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'outer_1',
-                'type' => 'outer_open',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'open' => [
-                    'id' => 'inner_1',
-                    'type' => 'inner_open',
+                [
+                    'id' => 'outer_1',
+                    'type' => 'outer_open',
                     'schemaUrl' => 'test.json',
                     'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'inner_1',
+                            'type' => 'inner_open',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'close_outer',
-                'type' => 'outer_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['outer' => true],
-                'openId' => 'outer_1',
-                'close' => [
-                    'id' => 'close_inner',
-                    'type' => 'inner_close',
+                [
+                    'id' => 'close_outer',
+                    'type' => 'outer_close',
                     'schemaUrl' => 'test.json',
-                    'context' => ['inner' => true],
-                    'openId' => 'inner_1',
+                    'context' => ['outer' => true],
+                    'openId' => 'outer_1',
+                    'close' => [
+                        [
+                            'id' => 'close_inner',
+                            'type' => 'inner_close',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['inner' => true],
+                            'openId' => 'inner_1',
+                        ],
+                    ],
                 ],
             ],
             'events' => [],
@@ -593,17 +726,21 @@ final class LogDataParserTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'process_open',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'process_open',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'process_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['result' => 'ok'],
-                'openId' => 'does_not_exist',
+                [
+                    'id' => 'close_1',
+                    'type' => 'process_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['result' => 'ok'],
+                    'openId' => 'does_not_exist',
+                ],
             ],
             'events' => [],
         ];

--- a/tests/Stree/StreeCommandTest.php
+++ b/tests/Stree/StreeCommandTest.php
@@ -69,17 +69,21 @@ final class StreeCommandTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'test_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.005],
+                [
+                    'id' => 'test_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['executionTime' => 0.005],
+                ],
             ],
             'close' => [
-                'id' => 'test_close_1',
-                'type' => 'test_close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'test_1',
+                [
+                    'id' => 'test_close_1',
+                    'type' => 'test_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'test_1',
+                ],
             ],
             'events' => [],
         ];
@@ -102,28 +106,36 @@ final class StreeCommandTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'parent_1',
-                'type' => 'parent',
-                'schemaUrl' => 'test.json',
-                'context' => ['name' => 'root'],
-                'open' => [
-                    'id' => 'child_1',
-                    'type' => 'child',
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent',
                     'schemaUrl' => 'test.json',
-                    'context' => ['name' => 'nested'],
+                    'context' => ['name' => 'root'],
                     'open' => [
-                        'id' => 'grandchild_1',
-                        'type' => 'grandchild',
-                        'schemaUrl' => 'test.json',
-                        'context' => ['name' => 'deep'],
+                        [
+                            'id' => 'child_1',
+                            'type' => 'child',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['name' => 'nested'],
+                            'open' => [
+                                [
+                                    'id' => 'grandchild_1',
+                                    'type' => 'grandchild',
+                                    'schemaUrl' => 'test.json',
+                                    'context' => ['name' => 'deep'],
+                                ],
+                            ],
+                        ],
                     ],
                 ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -147,22 +159,28 @@ final class StreeCommandTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'fast_1',
-                'type' => 'fast_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.001], // 1ms
-                'open' => [
-                    'id' => 'slow_1',
-                    'type' => 'slow_operation',
+                [
+                    'id' => 'fast_1',
+                    'type' => 'fast_operation',
                     'schemaUrl' => 'test.json',
-                    'context' => ['executionTime' => 0.020], // 20ms
+                    'context' => ['executionTime' => 0.001], // 1ms
+                    'open' => [
+                        [
+                            'id' => 'slow_1',
+                            'type' => 'slow_operation',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['executionTime' => 0.020], // 20ms
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -183,8 +201,8 @@ final class StreeCommandTest extends TestCase
     public function testJsonPassthrough(): void
     {
         $logData = [
-            'open' => ['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []],
-            'close' => ['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []],
+            'open' => [['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []]],
+            'close' => [['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []]],
             'events' => [],
         ];
 
@@ -205,8 +223,8 @@ final class StreeCommandTest extends TestCase
     public function testShortOptions(): void
     {
         $logData = [
-            'open' => ['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []],
-            'close' => ['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []],
+            'open' => [['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []]],
+            'close' => [['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []]],
             'events' => [],
         ];
 
@@ -247,8 +265,8 @@ final class StreeCommandTest extends TestCase
     public function testValuesFlagAccepted(): void
     {
         $logData = [
-            'open' => ['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []],
-            'close' => ['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []],
+            'open' => [['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => []]],
+            'close' => [['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []]],
             'events' => [],
         ];
 
@@ -266,8 +284,8 @@ final class StreeCommandTest extends TestCase
     public function testThresholdParsing(): void
     {
         $logData = [
-            'open' => ['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => ['executionTime' => 0.5]],
-            'close' => ['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []],
+            'open' => [['id' => 'test_1', 'type' => 'test', 'schemaUrl' => 'test.json', 'context' => ['executionTime' => 0.5]]],
+            'close' => [['id' => 'close_1', 'type' => 'close', 'schemaUrl' => 'test.json', 'context' => []]],
             'events' => [],
         ];
 

--- a/tests/Stree/TreeRendererTest.php
+++ b/tests/Stree/TreeRendererTest.php
@@ -16,17 +16,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'test_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.005],
+                [
+                    'id' => 'test_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['executionTime' => 0.005],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'test_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'test_1',
+                ],
             ],
             'events' => [],
         ];
@@ -45,17 +49,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'op_1',
-                'type' => 'some_op',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.010],
+                [
+                    'id' => 'op_1',
+                    'type' => 'some_op',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['executionTime' => 0.010],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'op_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'op_1',
+                ],
             ],
             'events' => [],
         ];
@@ -75,22 +83,28 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'parent_1',
-                'type' => 'parent_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'open' => [
-                    'id' => 'child_1',
-                    'type' => 'child_operation',
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent_operation',
                     'schemaUrl' => 'test.json',
                     'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'child_1',
+                            'type' => 'child_operation',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [],
         ];
@@ -109,17 +123,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'operation_1',
-                'type' => 'test_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'operation_1',
+                    'type' => 'test_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'operation_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'operation_1',
+                ],
             ],
             'events' => [
                 [
@@ -147,22 +165,28 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'parent_1',
-                'type' => 'parent_operation',
-                'schemaUrl' => 'test.json',
-                'context' => ['executionTime' => 0.050], // 50ms - above threshold
-                'open' => [
-                    'id' => 'fast_1',
-                    'type' => 'fast_operation',
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent_operation',
                     'schemaUrl' => 'test.json',
-                    'context' => ['executionTime' => 0.001], // 1ms - below threshold
+                    'context' => ['executionTime' => 0.050], // 50ms - above threshold
+                    'open' => [
+                        [
+                            'id' => 'fast_1',
+                            'type' => 'fast_operation',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['executionTime' => 0.001], // 1ms - below threshold
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'close_1',
+                    'type' => 'close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'events' => [
                 [
@@ -192,12 +216,14 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'op_1',
-                'type' => 'some_operation',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'op_1',
+                    'type' => 'some_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
-            'close' => null,
+            'close' => [],
             'events' => [],
         ];
 
@@ -213,17 +239,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'op_1',
-                'type' => 'payment',
-                'schemaUrl' => 'test.json',
-                'context' => ['amount' => 100],
+                [
+                    'id' => 'op_1',
+                    'type' => 'payment',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['amount' => 100],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'payment_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['success' => false],
-                'openId' => 'op_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'payment_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['success' => false],
+                    'openId' => 'op_1',
+                ],
             ],
             'events' => [],
         ];
@@ -240,29 +270,37 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'parent_1',
-                'type' => 'checkout',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'open' => [
-                    'id' => 'child_1',
-                    'type' => 'charge',
+                [
+                    'id' => 'parent_1',
+                    'type' => 'checkout',
                     'schemaUrl' => 'test.json',
-                    'context' => ['amount' => 100],
+                    'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'child_1',
+                            'type' => 'charge',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['amount' => 100],
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'parent_close',
-                'type' => 'checkout_close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'parent_1',
-                'close' => [
-                    'id' => 'child_close',
-                    'type' => 'charge_close',
+                [
+                    'id' => 'parent_close',
+                    'type' => 'checkout_close',
                     'schemaUrl' => 'test.json',
-                    'context' => ['success' => false],
-                    'openId' => 'child_1',
+                    'context' => [],
+                    'openId' => 'parent_1',
+                    'close' => [
+                        [
+                            'id' => 'child_close',
+                            'type' => 'charge_close',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['success' => false],
+                            'openId' => 'child_1',
+                        ],
+                    ],
                 ],
             ],
             'events' => [],
@@ -283,17 +321,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'op_1',
-                'type' => 'some_op',
-                'schemaUrl' => 'test.json',
-                'context' => ['operation' => 'validate', 'input' => 'data'],
+                [
+                    'id' => 'op_1',
+                    'type' => 'some_op',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['operation' => 'validate', 'input' => 'data'],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'some_op_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['result' => 'ok'],
-                'openId' => 'op_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'some_op_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['result' => 'ok'],
+                    'openId' => 'op_1',
+                ],
             ],
             'events' => [],
         ];
@@ -314,20 +356,24 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'meta_1',
-                'type' => 'metamorphosis_open',
-                'schemaUrl' => 'test.json',
-                'context' => [
-                    'fromClass' => 'Be\\Skeleton\\Input\\HelloInput',
-                    'beAttribute' => '#[Be(Be\\Skeleton\\Final\\Hello::class)]',
+                [
+                    'id' => 'meta_1',
+                    'type' => 'metamorphosis_open',
+                    'schemaUrl' => 'test.json',
+                    'context' => [
+                        'fromClass' => 'Be\\Skeleton\\Input\\HelloInput',
+                        'beAttribute' => '#[Be(Be\\Skeleton\\Final\\Hello::class)]',
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'meta_close_1',
-                'type' => 'metamorphosis_close',
-                'schemaUrl' => 'test.json',
-                'context' => ['finalClass' => 'Be\\Skeleton\\Final\\Hello'],
-                'openId' => 'meta_1',
+                [
+                    'id' => 'meta_close_1',
+                    'type' => 'metamorphosis_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => ['finalClass' => 'Be\\Skeleton\\Final\\Hello'],
+                    'openId' => 'meta_1',
+                ],
             ],
             'events' => [],
         ];
@@ -349,17 +395,21 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'op_1',
-                'type' => 'fake_open',
-                'schemaUrl' => 'test.json',
-                'context' => [],
+                [
+                    'id' => 'op_1',
+                    'type' => 'fake_open',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                ],
             ],
             'close' => [
-                'id' => 'close_1',
-                'type' => 'fake_close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'op_1',
+                [
+                    'id' => 'close_1',
+                    'type' => 'fake_close',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'openId' => 'op_1',
+                ],
             ],
             'events' => [],
         ];
@@ -382,29 +432,37 @@ final class TreeRendererTest extends TestCase
     {
         $logData = [
             'open' => [
-                'id' => 'root_1',
-                'type' => 'container',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'open' => [
-                    'id' => 'child_1',
-                    'type' => 'fake_open',
+                [
+                    'id' => 'root_1',
+                    'type' => 'container',
                     'schemaUrl' => 'test.json',
                     'context' => [],
+                    'open' => [
+                        [
+                            'id' => 'child_1',
+                            'type' => 'fake_open',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                        ],
+                    ],
                 ],
             ],
             'close' => [
-                'id' => 'root_close',
-                'type' => 'container_close',
-                'schemaUrl' => 'test.json',
-                'context' => [],
-                'openId' => 'root_1',
-                'close' => [
-                    'id' => 'child_close',
-                    'type' => 'fake_close',
+                [
+                    'id' => 'root_close',
+                    'type' => 'container_close',
                     'schemaUrl' => 'test.json',
                     'context' => [],
-                    'openId' => 'child_1',
+                    'openId' => 'root_1',
+                    'close' => [
+                        [
+                            'id' => 'child_close',
+                            'type' => 'fake_close',
+                            'schemaUrl' => 'test.json',
+                            'context' => [],
+                            'openId' => 'child_1',
+                        ],
+                    ],
                 ],
             ],
             'events' => [],

--- a/tests/experimental/LogDrivenTesting/RequestResponseAggregator.php
+++ b/tests/experimental/LogDrivenTesting/RequestResponseAggregator.php
@@ -28,11 +28,15 @@ final class RequestResponseAggregator
 
         // Extract all open operations from nested structure
         $openOperations = [];
-        $this->extractOpenOperations($logJson->open, $openOperations);
+        foreach ($logJson->open as $rootOpen) {
+            $this->extractOpenOperations($rootOpen, $openOperations);
+        }
 
         // Extract all close operations from nested structure
         $closeOperations = [];
-        $this->extractCloseOperations($logJson->close, $closeOperations);
+        foreach ($logJson->close as $rootClose) {
+            $this->extractCloseOperations($rootClose, $closeOperations);
+        }
 
         // Match open and close operations by base operation ID
         // For type-based IDs like "validation_1" and "validation_complete_1",
@@ -58,8 +62,8 @@ final class RequestResponseAggregator
     {
         $operations[] = $open;
 
-        if ($open->open !== null) {
-            $this->extractOpenOperations($open->open, $operations);
+        foreach ($open->open as $child) {
+            $this->extractOpenOperations($child, $operations);
         }
     }
 
@@ -68,16 +72,12 @@ final class RequestResponseAggregator
      *
      * @param array<int, EventEntry> $operations
      */
-    private function extractCloseOperations(EventEntry|null $close, array &$operations): void
+    private function extractCloseOperations(EventEntry $close, array &$operations): void
     {
-        if ($close === null) {
-            return;
-        }
-
         $operations[] = $close;
 
-        if ($close->close !== null) {
-            $this->extractCloseOperations($close->close, $operations);
+        foreach ($close->close as $child) {
+            $this->extractCloseOperations($child, $operations);
         }
     }
 

--- a/tests/experimental/LogDrivenTestingExperiment.php
+++ b/tests/experimental/LogDrivenTestingExperiment.php
@@ -13,6 +13,7 @@ use Koriym\SemanticLogger\Experimental\LogDrivenTesting\RequestResponseAggregato
 use Koriym\SemanticLogger\SemanticLogger;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
 use function count;
 use function json_encode;
 use function sprintf;
@@ -56,8 +57,8 @@ final class LogDrivenTestingExperiment extends TestCase
 
         // Debug output
         echo "\n=== LogJson Debug ===\n";
-        echo 'Open: ' . json_encode($logJson->open->toArray(), JSON_PRETTY_PRINT) . "\n";
-        echo 'Close: ' . json_encode($logJson->close->toArray(), JSON_PRETTY_PRINT) . "\n";
+        echo 'Open: ' . json_encode(array_map(static fn ($entry) => $entry->toArray(), $logJson->open), JSON_PRETTY_PRINT) . "\n";
+        echo 'Close: ' . json_encode(array_map(static fn ($entry) => $entry->toArray(), $logJson->close), JSON_PRETTY_PRINT) . "\n";
         echo 'Pairs found: ' . count($pairs) . "\n";
 
         $this->assertCount(2, $pairs);


### PR DESCRIPTION
## Summary

Fixes [#24](https://github.com/koriym/Koriym.SemanticLogger/issues/24).

`buildNestedOpen()` reconstructed a hierarchy from completed-operation order alone, with no record of actual parent-child relationships. Sequential `open/close` pairs at the same level were falsely nested — `open_2` wrapped `open_1` whenever they were siblings. The regression surfaced in Be Framework's metamorphosis-chain logs (e.g. [medical-triage.json](https://github.com/be-framework/be-patterns/blob/1.x/demos/medical-triage/var/log/medical-triage.json)): `becoming_open_2` appeared as the root with `becoming_open_1` nested inside.

## Fix

- `OpenCloseEntry` carries `parentId` and a list of `open` children.
- `EventEntry`'s `close` becomes a list of nested closes.
- `LogJson`'s `open` and `close` become top-level lists (multiple roots allowed).
- `SemanticLogger` captures the real parent at `open()` time via the open stack, then groups completed operations by `parentId` when flushing — no more reconstruction from close order.
- `DevSemanticLogger` walks the new list shape when attaching profiles.
- `Stree/LogDataParser` walks the new list shape; the single-root constraint is enforced at render time (multi-root logs throw a clear error for `stree`).
- Schema, demo JSON, and all tests updated.

## Schema change

`open` and `close` are now arrays of entries rather than single entries. Nested `open` (within an entry) and nested `close` (within a close entry) are also arrays. This is a breaking change to the on-wire JSON shape; downstream consumers (stree, validators) are updated in this PR. @mgp25 cc — renderers relying on single-entry shape need the same treatment.

## Tests

- New regression tests in [SemanticLoggerTest.php](tests/SemanticLoggerTest.php):
  - `testSequentialSiblingsAreRecordedAsSiblings` — two top-level open/close pairs stay siblings.
  - `testOuterWithTwoSiblingInnersKeepsRealOrder` — one outer with two sibling inners preserves real chronological order.
- All 207 existing tests migrated to the list-based shape and pass.
- `phpstan` clean, `phpcs` clean.

## Test plan

- [x] `vendor/bin/phpunit` — 207 green.
- [x] `composer phpstan` — no errors.
- [x] `composer cs` — no errors.
- [ ] Downstream verification: [be-framework/be-framework](https://github.com/koriym/be-framework) chain-wrap PR (forthcoming) produces a `becoming_chain_open` root with `becoming_open_N` siblings for the metamorphosis chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured semantic logging format to use array-based entries for operations instead of single nested objects, enabling improved tracking of concurrent and sibling operations.
  * Updated logging schema to reflect the new array structure for open and close operation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->