### PR TITLE
Nest close entries under matching open in dev logs

### DIFF
--- a/src/DevLogger.php
+++ b/src/DevLogger.php
@@ -46,7 +46,7 @@ final class DevLogger
 
     public function saveToFile(LogJson $logData): void
     {
-        $jsonContent = json_encode($logData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $jsonContent = json_encode($logData->toTreeArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         if ($jsonContent === false) {
             error_log('DevLogger: JSON encoding failed for semantic log data');
 

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -8,6 +8,7 @@ use JsonSerializable;
 use Override;
 
 use function array_map;
+use function is_array;
 
 final class LogJson implements JsonSerializable
 {
@@ -49,6 +50,112 @@ final class LogJson implements JsonSerializable
 
         if (! empty($this->links)) {
             $result['links'] = $this->links;
+        }
+
+        return $result;
+    }
+
+    /** @return array<string, mixed> */
+    public function toTreeArray(): array
+    {
+        $closeByOpenId = [];
+        $this->indexCloses($this->close, $closeByOpenId);
+        $eventsByOpenId = $this->groupEventsByOpenId($this->events);
+
+        $result = [
+            '$schema' => $this->schemaUrl,
+            'open' => array_map(
+                fn (OpenCloseEntry $entry): array => $this->buildTreeOpenEntry($entry, $closeByOpenId, $eventsByOpenId),
+                $this->open,
+            ),
+        ];
+
+        if (isset($eventsByOpenId['']) && $eventsByOpenId[''] !== []) {
+            $result['events'] = array_map(static fn (EventEntry $event): array => $event->toArray(), $eventsByOpenId['']);
+        }
+
+        if (! empty($this->links)) {
+            $result['links'] = $this->links;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, EventEntry>       $closeByOpenId
+     * @param array<string, list<EventEntry>> $eventsByOpenId
+     *
+     * @return array<string, mixed>
+     */
+    private function buildTreeOpenEntry(OpenCloseEntry $entry, array $closeByOpenId, array $eventsByOpenId): array
+    {
+        $result = $entry->toArray();
+
+        $events = $eventsByOpenId[$entry->id] ?? [];
+        if ($events !== []) {
+            $result['events'] = array_map(static fn (EventEntry $event): array => $event->toArray(), $events);
+        }
+
+        if (isset($closeByOpenId[$entry->id])) {
+            $result['close'] = $this->singleCloseToArray($closeByOpenId[$entry->id]);
+        }
+
+        if (! isset($result['open']) || ! is_array($result['open'])) {
+            return $result;
+        }
+
+        $result['open'] = array_map(
+            fn (OpenCloseEntry $child): array => $this->buildTreeOpenEntry($child, $closeByOpenId, $eventsByOpenId),
+            $entry->open,
+        );
+
+        return $result;
+    }
+
+    /**
+     * @param list<EventEntry>          $closes
+     * @param array<string, EventEntry> $closeByOpenId
+     */
+    private function indexCloses(array $closes, array &$closeByOpenId): void
+    {
+        foreach ($closes as $close) {
+            if ($close->openId !== null) {
+                $closeByOpenId[$close->openId] = $close;
+            }
+
+            if ($close->close !== []) {
+                $this->indexCloses($close->close, $closeByOpenId);
+            }
+        }
+    }
+
+    /**
+     * @param list<EventEntry> $events
+     *
+     * @return array<string, list<EventEntry>>
+     */
+    private function groupEventsByOpenId(array $events): array
+    {
+        $eventsByOpenId = [];
+        foreach ($events as $event) {
+            $eventsByOpenId[$event->openId ?? ''][] = $event;
+        }
+
+        return $eventsByOpenId;
+    }
+
+    /** @return array<string, mixed> */
+    private function singleCloseToArray(EventEntry $close): array
+    {
+        $result = [
+            'id' => $close->id,
+            'type' => $close->type,
+            'schemaUrl' => $close->schemaUrl,
+            'context' => $close->context,
+        ];
+
+        if ($close->profile !== null) {
+            $result['profile'] = $close->profile->jsonSerialize();
         }
 
         return $result;

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -8,7 +8,6 @@ use JsonSerializable;
 use Override;
 
 use function array_map;
-use function is_array;
 
 final class LogJson implements JsonSerializable
 {
@@ -61,6 +60,8 @@ final class LogJson implements JsonSerializable
         $closeByOpenId = [];
         $this->indexCloses($this->close, $closeByOpenId);
         $eventsByOpenId = $this->groupEventsByOpenId($this->events);
+        $openIds = [];
+        $this->collectOpenIds($this->open, $openIds);
 
         $result = [
             '$schema' => $this->schemaUrl,
@@ -70,8 +71,9 @@ final class LogJson implements JsonSerializable
             ),
         ];
 
-        if (isset($eventsByOpenId['']) && $eventsByOpenId[''] !== []) {
-            $result['events'] = array_map(static fn (EventEntry $event): array => $event->toArray(), $eventsByOpenId['']);
+        $topLevelEvents = $this->topLevelTreeEvents($openIds);
+        if ($topLevelEvents !== []) {
+            $result['events'] = array_map(static fn (EventEntry $event): array => $event->toArray(), $topLevelEvents);
         }
 
         if (! empty($this->links)) {
@@ -100,7 +102,9 @@ final class LogJson implements JsonSerializable
             $result['close'] = $this->singleCloseToArray($closeByOpenId[$entry->id]);
         }
 
-        if (! isset($result['open']) || ! is_array($result['open'])) {
+        if ($entry->open === []) {
+            unset($result['open']);
+
             return $result;
         }
 
@@ -119,8 +123,9 @@ final class LogJson implements JsonSerializable
     private function indexCloses(array $closes, array &$closeByOpenId): void
     {
         foreach ($closes as $close) {
-            if ($close->openId !== null) {
-                $closeByOpenId[$close->openId] = $close;
+            $openId = $close->openId;
+            if ($openId !== null) {
+                $closeByOpenId[$openId] = $close;
             }
 
             if ($close->close !== []) {
@@ -142,6 +147,39 @@ final class LogJson implements JsonSerializable
         }
 
         return $eventsByOpenId;
+    }
+
+    /**
+     * @param list<OpenCloseEntry> $entries
+     * @param array<string, true>  $openIds
+     */
+    private function collectOpenIds(array $entries, array &$openIds): void
+    {
+        foreach ($entries as $entry) {
+            $openIds[$entry->id] = true;
+
+            if ($entry->open !== []) {
+                $this->collectOpenIds($entry->open, $openIds);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, true> $openIds
+     *
+     * @return list<EventEntry>
+     */
+    private function topLevelTreeEvents(array $openIds): array
+    {
+        $topLevelEvents = [];
+        foreach ($this->events as $event) {
+            $openId = $event->openId;
+            if ($openId === null || ! isset($openIds[$openId])) {
+                $topLevelEvents[] = $event;
+            }
+        }
+
+        return $topLevelEvents;
     }
 
     /** @return array<string, mixed> */

--- a/src/Stree/LogDataParser.php
+++ b/src/Stree/LogDataParser.php
@@ -100,11 +100,15 @@ final class LogDataParser
         $node = new TreeNode($id, $type, $context, $executionTime, $parent);
 
         if (array_key_exists('close', $openEntry) && is_array($openEntry['close'])) {
-            $this->attachNestedCloseToNode($node, $openEntry['close']);
+            /** @var array<string, mixed> $closeEntry */
+            $closeEntry = $openEntry['close'];
+            $this->attachNestedCloseToNode($node, $closeEntry);
         }
 
         if (array_key_exists('events', $openEntry) && is_array($openEntry['events'])) {
-            $this->attachNestedEventsToNode($node, $openEntry['events']);
+            /** @var list<array<string, mixed>> $events */
+            $events = $openEntry['events'];
+            $this->attachNestedEventsToNode($node, $events);
         }
 
         // Walk nested sibling children (list shape).

--- a/src/Stree/LogDataParser.php
+++ b/src/Stree/LogDataParser.php
@@ -99,6 +99,14 @@ final class LogDataParser
 
         $node = new TreeNode($id, $type, $context, $executionTime, $parent);
 
+        if (array_key_exists('close', $openEntry) && is_array($openEntry['close'])) {
+            $this->attachNestedCloseToNode($node, $openEntry['close']);
+        }
+
+        if (array_key_exists('events', $openEntry) && is_array($openEntry['events'])) {
+            $this->attachNestedEventsToNode($node, $openEntry['events']);
+        }
+
         // Walk nested sibling children (list shape).
         if (array_key_exists('open', $openEntry) && is_array($openEntry['open'])) {
             /** @var list<array<string, mixed>> $children */
@@ -109,6 +117,41 @@ final class LogDataParser
         }
 
         return $node;
+    }
+
+    /** @param array<string, mixed> $closeEntry */
+    private function attachNestedCloseToNode(TreeNode $node, array $closeEntry): void
+    {
+        $type = self::stringifyScalar($closeEntry['type'] ?? null, 'unknown');
+        /** @var mixed $rawContext */
+        $rawContext = $closeEntry['context'] ?? [];
+        if (! is_array($rawContext)) {
+            $rawContext = [];
+        }
+
+        /** @var array<string, mixed> $context */
+        $context = $rawContext;
+        $node->setClose($type, $context);
+    }
+
+    /** @param list<array<string, mixed>> $events */
+    private function attachNestedEventsToNode(TreeNode $node, array $events): void
+    {
+        foreach ($events as $event) {
+            $eventId = self::stringifyScalar($event['id'] ?? null, 'unknown');
+            $eventType = self::stringifyScalar($event['type'] ?? null, 'unknown');
+            /** @var mixed $eventContext */
+            $eventContext = $event['context'] ?? [];
+            if (! is_array($eventContext)) {
+                $eventContext = [];
+            }
+
+            /** @var array<string, mixed> $eventContext */
+            $executionTime = $this->extractExecutionTime($eventContext);
+            $eventNode = new TreeNode($eventId, $eventType, $eventContext, $executionTime, $node);
+            $eventNode->isEvent = true;
+            $node->addChild($eventNode);
+        }
     }
 
     /** @param array<string, mixed>[] $events */

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -79,15 +79,10 @@ final class DevLoggerTest extends TestCase
         $this->assertIsArray($jsonFiles);
         $this->assertNotEmpty($jsonFiles);
 
-        $content = file_get_contents($jsonFiles[0]);
-        $this->assertIsString($content);
-        $data = json_decode($content, true);
-
-        $this->assertIsArray($data);
+        $data = $this->readLogData($jsonFiles[0]);
         $this->assertArrayHasKey('$schema', $data);
-        $this->assertArrayHasKey('open', $data);
-        $this->assertIsArray($data['open']);
-        $this->assertArrayHasKey('close', $data['open'][0]);
+        $root = $this->firstOpenEntry($data);
+        $this->assertArrayHasKey('close', $root);
     }
 
     public function testLogFileNestsCloseUnderMatchingOpen(): void
@@ -103,15 +98,14 @@ final class DevLoggerTest extends TestCase
         $this->assertIsArray($jsonFiles);
         $this->assertNotEmpty($jsonFiles);
 
-        $content = file_get_contents($jsonFiles[0]);
-        $this->assertIsString($content);
-        $data = json_decode($content, true);
+        $data = $this->readLogData($jsonFiles[0]);
+        $root = $this->firstOpenEntry($data);
+        $innerOpen = $this->firstChildOpenEntry($root);
 
-        $this->assertIsArray($data);
-        $this->assertSame('outer', $data['open'][0]['context']['message']);
-        $this->assertSame('outer complete', $data['open'][0]['close']['context']['message']);
-        $this->assertSame('inner', $data['open'][0]['open'][0]['context']['message']);
-        $this->assertSame('inner complete', $data['open'][0]['open'][0]['close']['context']['message']);
+        $this->assertSame('outer', $this->messageFromEntry($root));
+        $this->assertSame('outer complete', $this->messageFromEntry($this->closeFromEntry($root)));
+        $this->assertSame('inner', $this->messageFromEntry($innerOpen));
+        $this->assertSame('inner complete', $this->messageFromEntry($this->closeFromEntry($innerOpen)));
     }
 
     public function testSilentFailureOnJsonEncodingError(): void
@@ -182,5 +176,93 @@ final class DevLoggerTest extends TestCase
 
         // Verify files have different names
         $this->assertNotEquals($jsonFiles[0], $jsonFiles[1]);
+    }
+
+    /** @return array{'$schema'?: mixed, open: list<array<mixed, mixed>>} */
+    private function readLogData(string $file): array
+    {
+        $content = file_get_contents($file);
+        $this->assertIsString($content);
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('open', $data);
+        $openEntries = $data['open'];
+        $this->assertIsArray($openEntries);
+
+        $validatedOpenEntries = [];
+        foreach ($openEntries as $openEntry) {
+            $this->assertIsArray($openEntry);
+            $validatedOpenEntries[] = $openEntry;
+        }
+
+        return [
+            '$schema' => $data['$schema'] ?? null,
+            'open' => $validatedOpenEntries,
+        ];
+    }
+
+    /**
+     * @param array{'$schema'?: mixed, open: list<array<mixed, mixed>>} $data
+     *
+     * @return array<mixed, mixed>
+     */
+    private function firstOpenEntry(array $data): array
+    {
+        $this->assertNotEmpty($data['open']);
+
+        return $data['open'][0];
+    }
+
+    /**
+     * @param array<mixed, mixed> $entry
+     *
+     * @return array<mixed, mixed>
+     */
+    private function firstChildOpenEntry(array $entry): array
+    {
+        $this->assertArrayHasKey('open', $entry);
+        $children = $entry['open'];
+        $this->assertIsArray($children);
+
+        $validatedChildren = [];
+        foreach ($children as $child) {
+            $this->assertIsArray($child);
+            $validatedChildren[] = $child;
+        }
+
+        $this->assertNotEmpty($validatedChildren);
+
+        return $validatedChildren[0];
+    }
+
+    /**
+     * @param array<mixed, mixed> $entry
+     *
+     * @return array<mixed, mixed>
+     */
+    private function closeFromEntry(array $entry): array
+    {
+        $this->assertArrayHasKey('close', $entry);
+        $close = $entry['close'];
+        $this->assertIsArray($close);
+
+        $validatedClose = [];
+        foreach ($close as $key => $value) {
+            $validatedClose[$key] = $value;
+        }
+
+        return $validatedClose;
+    }
+
+    /** @param array<mixed, mixed> $entry */
+    private function messageFromEntry(array $entry): string
+    {
+        $this->assertArrayHasKey('context', $entry);
+        $context = $entry['context'];
+        $this->assertIsArray($context);
+        $this->assertArrayHasKey('message', $context);
+        $this->assertIsString($context['message']);
+
+        return $context['message'];
     }
 }

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -178,13 +178,14 @@ final class DevLoggerTest extends TestCase
         $this->assertNotEquals($jsonFiles[0], $jsonFiles[1]);
     }
 
-    /** @return array{'$schema'?: mixed, open: list<array<mixed, mixed>>} */
+    /** @return array{open: list<array<mixed, mixed>>} */
     private function readLogData(string $file): array
     {
         $content = file_get_contents($file);
         $this->assertIsString($content);
         $data = json_decode($content, true);
         $this->assertIsArray($data);
+        $this->assertArrayHasKey('$schema', $data);
         $this->assertArrayHasKey('open', $data);
         $openEntries = $data['open'];
         $this->assertIsArray($openEntries);
@@ -195,14 +196,11 @@ final class DevLoggerTest extends TestCase
             $validatedOpenEntries[] = $openEntry;
         }
 
-        return [
-            '$schema' => $data['$schema'] ?? null,
-            'open' => $validatedOpenEntries,
-        ];
+        return ['open' => $validatedOpenEntries];
     }
 
     /**
-     * @param array{'$schema'?: mixed, open: list<array<mixed, mixed>>} $data
+     * @param array{open: list<array<mixed, mixed>>} $data
      *
      * @return array<mixed, mixed>
      */

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -177,7 +177,7 @@ final class DevLoggerTest extends TestCase
         $this->assertNotEquals($jsonFiles[0], $jsonFiles[1]);
     }
 
-    /** @return array{open: list<array<mixed, mixed>>} */
+    /** @return array{open: list<array<string, mixed>>} */
     private function readLogData(string $file): array
     {
         $content = file_get_contents($file);
@@ -192,16 +192,16 @@ final class DevLoggerTest extends TestCase
         $validatedOpenEntries = [];
         foreach ($openEntries as $openEntry) {
             $this->assertIsArray($openEntry);
-            $validatedOpenEntries[] = $openEntry;
+            $validatedOpenEntries[] = $this->normalizeEntry($openEntry);
         }
 
         return ['open' => $validatedOpenEntries];
     }
 
     /**
-     * @param array{open: list<array<mixed, mixed>>} $data
+     * @param array{open: list<array<string, mixed>>} $data
      *
-     * @return array<mixed, mixed>
+     * @return array<string, mixed>
      */
     private function firstOpenEntry(array $data): array
     {
@@ -211,9 +211,9 @@ final class DevLoggerTest extends TestCase
     }
 
     /**
-     * @param array<mixed, mixed> $entry
+     * @param array<string, mixed> $entry
      *
-     * @return array<mixed, mixed>
+     * @return array<string, mixed>
      */
     private function firstChildOpenEntry(array $entry): array
     {
@@ -224,7 +224,7 @@ final class DevLoggerTest extends TestCase
         $validatedChildren = [];
         foreach ($children as $child) {
             $this->assertIsArray($child);
-            $validatedChildren[] = $child;
+            $validatedChildren[] = $this->normalizeEntry($child);
         }
 
         $this->assertNotEmpty($validatedChildren);
@@ -233,9 +233,9 @@ final class DevLoggerTest extends TestCase
     }
 
     /**
-     * @param array<mixed, mixed> $entry
+     * @param array<string, mixed> $entry
      *
-     * @return array<mixed, mixed>
+     * @return array<string, mixed>
      */
     private function closeFromEntry(array $entry): array
     {
@@ -243,15 +243,10 @@ final class DevLoggerTest extends TestCase
         $close = $entry['close'];
         $this->assertIsArray($close);
 
-        $validatedClose = [];
-        foreach ($close as $key => $value) {
-            $validatedClose[$key] = $value;
-        }
-
-        return $validatedClose;
+        return $this->normalizeEntry($close);
     }
 
-    /** @param array<mixed, mixed> $entry */
+    /** @param array<string, mixed> $entry */
     private function messageFromEntry(array $entry): string
     {
         $this->assertArrayHasKey('context', $entry);
@@ -261,5 +256,21 @@ final class DevLoggerTest extends TestCase
         $this->assertIsString($context['message']);
 
         return $context['message'];
+    }
+
+    /**
+     * @param array<mixed, mixed> $entry
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeEntry(array $entry): array
+    {
+        $normalized = [];
+        foreach ($entry as $key => $value) {
+            $this->assertIsString($key);
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
     }
 }

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -80,7 +80,6 @@ final class DevLoggerTest extends TestCase
         $this->assertNotEmpty($jsonFiles);
 
         $data = $this->readLogData($jsonFiles[0]);
-        $this->assertArrayHasKey('$schema', $data);
         $root = $this->firstOpenEntry($data);
         $this->assertArrayHasKey('close', $root);
     }

--- a/tests/DevLoggerTest.php
+++ b/tests/DevLoggerTest.php
@@ -86,7 +86,32 @@ final class DevLoggerTest extends TestCase
         $this->assertIsArray($data);
         $this->assertArrayHasKey('$schema', $data);
         $this->assertArrayHasKey('open', $data);
-        $this->assertArrayHasKey('close', $data);
+        $this->assertIsArray($data['open']);
+        $this->assertArrayHasKey('close', $data['open'][0]);
+    }
+
+    public function testLogFileNestsCloseUnderMatchingOpen(): void
+    {
+        $outer = $this->logger->open(new FakeContext('outer'));
+        $inner = $this->logger->open(new FakeContext('inner'));
+        $this->logger->close(new FakeContext('inner complete'), $inner);
+        $this->logger->close(new FakeContext('outer complete'), $outer);
+
+        $this->devLogger->log($this->logger);
+
+        $jsonFiles = glob($this->logDirectory . '/semantic-dev-*.json');
+        $this->assertIsArray($jsonFiles);
+        $this->assertNotEmpty($jsonFiles);
+
+        $content = file_get_contents($jsonFiles[0]);
+        $this->assertIsString($content);
+        $data = json_decode($content, true);
+
+        $this->assertIsArray($data);
+        $this->assertSame('outer', $data['open'][0]['context']['message']);
+        $this->assertSame('outer complete', $data['open'][0]['close']['context']['message']);
+        $this->assertSame('inner', $data['open'][0]['open'][0]['context']['message']);
+        $this->assertSame('inner complete', $data['open'][0]['open'][0]['close']['context']['message']);
     }
 
     public function testSilentFailureOnJsonEncodingError(): void

--- a/tests/LogSessionTest.php
+++ b/tests/LogSessionTest.php
@@ -60,4 +60,120 @@ final class LogSessionTest extends TestCase
         $this->assertSame('end_1', $session->close[0]->id);
         $this->assertSame('end', $session->close[0]->type);
     }
+
+    public function testToTreeArrayPreservesOrphanEventsAtTopLevel(): void
+    {
+        $open = new OpenCloseEntry('start_1', 'start', 'https://example.com/start.json', ['start' => true]);
+        $events = [
+            new EventEntry('nested_1', 'nested', 'https://example.com/nested.json', ['event' => 'nested'], 'start_1'),
+            new EventEntry('orphan_1', 'orphan', 'https://example.com/orphan.json', ['event' => 'orphan'], 'missing_1'),
+            new EventEntry('top_1', 'top', 'https://example.com/top.json', ['event' => 'top']),
+        ];
+        $close = new EventEntry('end_1', 'end', 'https://example.com/end.json', ['end' => true], 'start_1');
+
+        $session = new LogJson(
+            'https://schema.example.com/complete.json',
+            [$open],
+            [$close],
+            $events,
+        );
+
+        $tree = $session->toTreeArray();
+        $topLevelEvents = $this->treeEvents($tree);
+        $openEntries = $this->treeOpenEntries($tree);
+        $rootEntry = $openEntries[0];
+        $nestedEvents = $this->entryEvents($rootEntry);
+
+        $this->assertCount(1, $openEntries);
+        $this->assertCount(2, $topLevelEvents);
+        $this->assertSame('orphan_1', $this->entryId($topLevelEvents[0]));
+        $this->assertSame('top_1', $this->entryId($topLevelEvents[1]));
+        $this->assertCount(1, $nestedEvents);
+        $this->assertSame('nested_1', $this->entryId($nestedEvents[0]));
+    }
+
+    /**
+     * @param array<string, mixed> $tree
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function treeOpenEntries(array $tree): array
+    {
+        $this->assertArrayHasKey('open', $tree);
+        $openEntries = $tree['open'];
+        $this->assertIsArray($openEntries);
+
+        $validatedOpenEntries = [];
+        foreach ($openEntries as $openEntry) {
+            $this->assertIsArray($openEntry);
+            $validatedOpenEntries[] = $this->normalizeEntry($openEntry);
+        }
+
+        return $validatedOpenEntries;
+    }
+
+    /**
+     * @param array<string, mixed> $tree
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function treeEvents(array $tree): array
+    {
+        $this->assertArrayHasKey('events', $tree);
+        $events = $tree['events'];
+        $this->assertIsArray($events);
+
+        $validatedEvents = [];
+        foreach ($events as $event) {
+            $this->assertIsArray($event);
+            $validatedEvents[] = $this->normalizeEntry($event);
+        }
+
+        return $validatedEvents;
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function entryEvents(array $entry): array
+    {
+        $this->assertArrayHasKey('events', $entry);
+        $events = $entry['events'];
+        $this->assertIsArray($events);
+
+        $validatedEvents = [];
+        foreach ($events as $event) {
+            $this->assertIsArray($event);
+            $validatedEvents[] = $this->normalizeEntry($event);
+        }
+
+        return $validatedEvents;
+    }
+
+    /** @param array<string, mixed> $entry */
+    private function entryId(array $entry): string
+    {
+        $this->assertArrayHasKey('id', $entry);
+        $this->assertIsString($entry['id']);
+
+        return $entry['id'];
+    }
+
+    /**
+     * @param array<mixed, mixed> $entry
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeEntry(array $entry): array
+    {
+        $normalized = [];
+        foreach ($entry as $key => $value) {
+            $this->assertIsString($key);
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
 }

--- a/tests/Stree/LogDataParserTest.php
+++ b/tests/Stree/LogDataParserTest.php
@@ -85,6 +85,59 @@ final class LogDataParserTest extends TestCase
         $this->assertSame(0.010, $child->executionTime);
     }
 
+    public function testParseTreeShapedLogData(): void
+    {
+        $logData = [
+            'open' => [
+                [
+                    'id' => 'parent_1',
+                    'type' => 'parent_operation',
+                    'schemaUrl' => 'test.json',
+                    'context' => [],
+                    'events' => [
+                        [
+                            'id' => 'event_1',
+                            'type' => 'infra_event',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['duration' => 0.002],
+                        ],
+                    ],
+                    'open' => [
+                        [
+                            'id' => 'child_1',
+                            'type' => 'child_operation',
+                            'schemaUrl' => 'test.json',
+                            'context' => ['responseTime' => 0.010],
+                            'close' => [
+                                'id' => 'child_close_1',
+                                'type' => 'child_close',
+                                'schemaUrl' => 'test.json',
+                                'context' => ['status' => 'done'],
+                            ],
+                        ],
+                    ],
+                    'close' => [
+                        'id' => 'parent_close_1',
+                        'type' => 'parent_close',
+                        'schemaUrl' => 'test.json',
+                        'context' => ['status' => 'done'],
+                    ],
+                ],
+            ],
+        ];
+
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData($logData);
+
+        $this->assertSame('parent_1', $tree->id);
+        $this->assertSame('parent_close', $tree->closeType);
+        $this->assertCount(2, $tree->children);
+        $this->assertTrue($tree->children[0]->isEvent);
+        $this->assertSame('infra_event', $tree->children[0]->type);
+        $this->assertSame('child_1', $tree->children[1]->id);
+        $this->assertSame('child_close', $tree->children[1]->closeType);
+    }
+
     public function testParseSiblingChildren(): void
     {
         $logData = [


### PR DESCRIPTION
## Summary
- write development semantic logs in a tree-shaped form where each close is nested under its matching open
- keep stree compatible with both the legacy split open/close format and the new tree-shaped dev-log format
- add regression coverage for nested closes and tree-shaped parser input

## Why
The raw dev log was hard to read because open and close were emitted as separate parallel trees. Nesting each close under its matching open makes the saved JSON match the indentation model users expect while preserving the existing runtime API.

## Validation
- vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=512M
- vendor/bin/phpunit tests/DevLoggerTest.php tests/Stree/LogDataParserTest.php
- vendor/bin/phpunit tests/SemanticLoggerTest.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log output now supports hierarchical tree structures, with nested operations and events properly organized in the JSON format.

* **Tests**
  * Added test coverage validating tree-structured log data parsing and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->