### PR TITLE
[codex] Normalize domain types and add PHP skill

### DIFF
--- a/skills/php-domain-types/SKILL.md
+++ b/skills/php-domain-types/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: php-domain-types
+description: Introduce, refactor, and normalize domain type aliases in PHP projects, especially codebases checked by Psalm and/or PHPStan. Use when Codex needs to create or reorganize a `Types.php` catalog, replace repeated array shapes with named aliases, add `@psalm-import-type` or `@phpstan-import-type`, decide whether a structure is a domain concept or only an implementation detail, or repair static-analysis issues caused by alias refactors.
+---
+
+# PHP Domain Types
+
+## Overview
+
+Introduce shared type aliases only for concepts that carry stable meaning across the project. Centralize them, import them where reused, and keep static-analysis compatibility intact.
+
+## Workflow
+
+1. Inspect the project before naming anything.
+- Search for `@psalm-type`, `@phpstan-type`, `@psalm-import-type`, `@phpstan-import-type`, repeated `array{...}`, repeated `array<string, mixed>`, and repeated `list<...>`.
+- Check `composer.json`, CI config, and analyzer config to see whether Psalm, PHPStan, or both are active.
+
+2. Promote only real domain concepts into aliases.
+- Promote serialized payloads, transport envelopes, link lists, profile payloads, stable config groups, keyed maps by IDs or types, and reused collection shapes.
+- Keep local helper arrays, pass-by-reference accumulators, temporary analyzer workarounds, and concrete containers such as `SplStack` out of the catalog unless they are shared public concepts.
+
+3. Design the catalog as a bounded type dictionary.
+- Create one `Types.php` per namespace boundary or bounded context, not one repo-wide junk drawer.
+- Make the catalog non-instantiable.
+- Add `@psalm-suppress UnusedClass` if the class exists only to host aliases.
+- Group aliases by concern: scalar atoms, collections, serialized shapes, analyzer interop.
+
+4. Name aliases in domain language, not PHP plumbing language.
+- Prefer names such as `UserId`, `SchemaUrl`, `RouteParams`, `ValidationErrorsByField`, `EventsByRequestId`, `PublicEventData`.
+- Use suffixes consistently: `*List`, `*Map`, `*Set`, `*ById`, `*ByType`, `*Data`.
+- Use `*Array` only when the concrete serialized array shape itself is important.
+- Read [naming-patterns.md](references/naming-patterns.md) when names or boundaries are unclear.
+
+5. Integrate aliases incrementally.
+- Add aliases first.
+- Replace only repeated or semantically important docblocks.
+- Import shared aliases with `@psalm-import-type` and/or `@phpstan-import-type`.
+- Keep native PHP signatures honest; do not widen runtime types to match docblocks.
+- If a local helper becomes harder to understand after aliasing, leave it as a raw array annotation.
+
+6. Keep analyzer compatibility explicit.
+- Use tool-specific tags when the project runs both analyzers: `@psalm-type`, `@psalm-import-type`, `@psalm-return`, `@psalm-param`, `@phpstan-type`, `@phpstan-import-type`, `@phpstan-return`, `@phpstan-param`.
+- Do not assume a tool-specific alias will be understood through a plain `@return` or `@param`.
+- If optional keys become explicit and tests or analyzers start failing, update guards and fixtures instead of weakening the alias.
+
+7. Validate after each meaningful batch.
+- Run the analyzers and tests the project already uses.
+- Treat parser errors, invalid imports, and optional-key warnings as feedback on the alias boundary.
+- Prefer shrinking alias scope over adding suppressions when the catalog becomes fragile.
+
+## Heuristics
+
+- Introduce an alias when it clarifies a shared concept better than the raw shape.
+- Avoid introducing an alias only because a shape is long.
+- Split runtime structures from serialized structures when their meanings differ.
+- Prefer one good alias imported in many places over many near-duplicate aliases.
+- Rename weak aliases such as `Data`, `Info`, `Items`, or `Map` to something with a real subject.
+
+## Quick Checks
+
+- Does the alias express business, transport, persistence, or API meaning?
+- Is the shape reused across files or likely to be imported?
+- Does the alias make review easier than the raw shape?
+- Is the alias naming a stable thing, not a temporary implementation trick?
+- Will both active analyzers accept the way the alias is declared and imported?

--- a/skills/php-domain-types/agents/openai.yaml
+++ b/skills/php-domain-types/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PHP Domain Types"
+  short_description: "Introduce and normalize PHP domain type aliases"
+  default_prompt: "Use $php-domain-types to introduce or reorganize shared domain type aliases in this PHP project."

--- a/skills/php-domain-types/references/naming-patterns.md
+++ b/skills/php-domain-types/references/naming-patterns.md
@@ -1,0 +1,60 @@
+# Naming Patterns
+
+Use this file when alias names or catalog boundaries are unclear.
+
+## Favor
+
+- Scalar atoms: `UserId`, `OrderId`, `SchemaUrl`, `LocaleCode`
+- Lists: `UserIdList`, `ViolationList`, `RouteSegmentList`
+- Maps: `UsersById`, `HeadersByName`, `EventsByRequestId`
+- Sets: `EnabledFeatureSet`, `OperationIdSet`
+- Serialized payloads: `UserResponseData`, `ValidationErrorData`, `WebhookEnvelopeData`
+- Concrete serialized entries: `PublicEventArray`, `SchemaLinkArray`
+
+## Split by meaning
+
+- Use different aliases when the same data passes through different meanings.
+- Prefer `UserRow` for storage, `UserInputData` for inbound payloads, and `UserResponseData` for outbound payloads.
+- Prefer `OperationProfile` for an object and `OperationProfileData` for its serialized array shape.
+
+## Avoid
+
+- `Data`, `Info`, `Items`, `Map`, `Result` with no subject
+- One-off aliases for local helper arrays
+- Aliases that merely hide `array<string, mixed>` without adding meaning
+- Aliases for concrete containers such as `SplStack` unless they are part of a shared public abstraction
+
+## Mixed Analyzer Pattern
+
+When both Psalm and PHPStan are active, keep declarations and imports explicit.
+
+```php
+/**
+ * @psalm-type UserResponseData = array{id: non-empty-string, email: non-empty-string}
+ * @phpstan-type UserResponseData array{id: non-empty-string, email: non-empty-string}
+ */
+final class Types
+{
+    private function __construct()
+    {
+    }
+}
+```
+
+```php
+/**
+ * @psalm-import-type UserResponseData from Types
+ * @phpstan-import-type UserResponseData from Types
+ *
+ * @psalm-return UserResponseData
+ * @phpstan-return UserResponseData
+ */
+public function toArray(): array
+{
+    // ...
+}
+```
+
+## Decision Rule
+
+If the best alias name still sounds generic, the shape probably is not a domain type yet.

--- a/src/DevSemanticLogger.php
+++ b/src/DevSemanticLogger.php
@@ -14,18 +14,26 @@ use function array_pop;
 use function end;
 use function uniqid;
 
+/**
+ * @psalm-import-type EventEntryList from Types
+ * @psalm-import-type OperationProfilesById from Types
+ * @psalm-import-type SchemaLinks from Types
+ * @psalm-import-type WallTimesByOperationId from Types
+ * @psalm-import-type XdebugSegmentsByOperationId from Types
+ * @psalm-import-type XhprofSegmentsByOperationId from Types
+ */
 final class DevSemanticLogger implements SemanticLoggerInterface
 {
     /** @var array<string, PhpProfile> */
     private array $startedPhp = [];
 
-    /** @var array<string, float> */
+    /** @var WallTimesByOperationId */
     private array $wallTimes = [];
 
-    /** @var array<string, list<XdebugTrace>> */
+    /** @var XdebugSegmentsByOperationId */
     private array $xdebugSegments = [];
 
-    /** @var array<string, list<XHProfResult>> */
+    /** @var XhprofSegmentsByOperationId */
     private array $xhprofSegments = [];
 
     /** @var list<string> */
@@ -93,7 +101,7 @@ final class DevSemanticLogger implements SemanticLoggerInterface
         $this->inner->event($context);
     }
 
-    /** @param list<array{rel: string, href: string, title?: string, type?: string}> $links */
+    /** @param SchemaLinks $links */
     #[Override]
     public function flush(array $links = []): LogJson
     {
@@ -151,10 +159,10 @@ final class DevSemanticLogger implements SemanticLoggerInterface
      * Walk the close tree and, at each node, attach the matching OperationProfile
      * directly to that close entry when external profiler output was captured.
      *
-     * @param list<EventEntry>                $closes
-     * @param array<string, OperationProfile> $operations
+     * @param EventEntryList       $closes
+     * @param OperationProfilesById $operations
      *
-     * @return list<EventEntry>
+     * @return EventEntryList
      */
     private function attachProfilesToCloses(array $closes, array $operations): array
     {

--- a/src/DevSemanticLogger.php
+++ b/src/DevSemanticLogger.php
@@ -159,7 +159,7 @@ final class DevSemanticLogger implements SemanticLoggerInterface
      * Walk the close tree and, at each node, attach the matching OperationProfile
      * directly to that close entry when external profiler output was captured.
      *
-     * @param EventEntryList       $closes
+     * @param EventEntryList        $closes
      * @param OperationProfilesById $operations
      *
      * @return EventEntryList

--- a/src/DynamicSchemaGenerator.php
+++ b/src/DynamicSchemaGenerator.php
@@ -16,8 +16,6 @@ use function str_replace;
 /**
  * @psalm-import-type JsonMap from Types
  * @psalm-import-type SchemaTypeMap from Types
- *
- * Generates a tree-oriented semantic log schema with dynamic context validation.
  */
 final class DynamicSchemaGenerator
 {

--- a/src/DynamicSchemaGenerator.php
+++ b/src/DynamicSchemaGenerator.php
@@ -13,7 +13,12 @@ use function glob;
 use function is_file;
 use function str_replace;
 
-/** Generates a tree-oriented semantic log schema with dynamic context validation. */
+/**
+ * @psalm-import-type JsonMap from Types
+ * @psalm-import-type SchemaTypeMap from Types
+ *
+ * Generates a tree-oriented semantic log schema with dynamic context validation.
+ */
 final class DynamicSchemaGenerator
 {
     public function __construct(
@@ -25,7 +30,7 @@ final class DynamicSchemaGenerator
     /**
      * Generate tree-oriented public schema with dynamic type-based context validation.
      *
-     * @return array<string, mixed>
+     * @return JsonMap
      */
     public function generateCombinedSchema(): array
     {
@@ -91,7 +96,7 @@ final class DynamicSchemaGenerator
     /**
      * Discover all context types from schema files
      *
-     * @return array<string, string> Map of type => schema file path
+     * @return SchemaTypeMap Map of type => schema file path
      */
     private function discoverContextTypes(): array
     {
@@ -119,9 +124,9 @@ final class DynamicSchemaGenerator
     /**
      * Generate open entry schema with dynamic type validation.
      *
-     * @param array<string, string> $contextTypes
+     * @param SchemaTypeMap $contextTypes
      *
-     * @return array<string, mixed>
+     * @return JsonMap
      */
     private function generateOpenEntrySchema(array $contextTypes): array
     {
@@ -156,9 +161,9 @@ final class DynamicSchemaGenerator
     /**
      * Generate close entry schema with dynamic type validation.
      *
-     * @param array<string, string> $contextTypes
+     * @param SchemaTypeMap $contextTypes
      *
-     * @return array<string, mixed>
+     * @return JsonMap
      */
     private function generateCloseEntrySchema(array $contextTypes): array
     {
@@ -186,9 +191,9 @@ final class DynamicSchemaGenerator
     /**
      * Generate event entry schema with dynamic type validation.
      *
-     * @param array<string, string> $contextTypes
+     * @param SchemaTypeMap $contextTypes
      *
-     * @return array<string, mixed>
+     * @return JsonMap
      */
     private function generateEventEntrySchema(array $contextTypes): array
     {
@@ -215,9 +220,9 @@ final class DynamicSchemaGenerator
     /**
      * Generate if/then/else conditions for each context type
      *
-     * @param array<string, string> $contextTypes
+     * @param SchemaTypeMap $contextTypes
      *
-     * @return array<array<string, mixed>>
+     * @return list<JsonMap>
      */
     private function generateTypeConditions(array $contextTypes): array
     {
@@ -251,7 +256,7 @@ final class DynamicSchemaGenerator
         return './schemas/' . basename($filePath);
     }
 
-    /** @return array<string, mixed> */
+    /** @return JsonMap */
     private function generateSchemaUrlDefinition(): array
     {
         return [

--- a/src/EventEntry.php
+++ b/src/EventEntry.php
@@ -10,11 +10,15 @@ use Override;
 
 use function array_map;
 
+/**
+ * @psalm-import-type ContextData from Types
+ * @psalm-import-type EventEntryArray from Types
+ */
 final class EventEntry implements JsonSerializable
 {
     /**
-     * @param array<string, mixed> $context
-     * @param list<EventEntry>     $close   Child closes (zero or more) — immediate nested close entries in the order their opens closed.
+     * @param ContextData      $context
+     * @param list<EventEntry> $close Child closes (zero or more) — immediate nested close entries in the order their opens closed.
      */
     public function __construct(
         public readonly string $id,
@@ -54,7 +58,7 @@ final class EventEntry implements JsonSerializable
         );
     }
 
-    /** @return array<string, mixed> */
+    /** @return EventEntryArray */
     public function toArray(): array
     {
         $result = [

--- a/src/EventEntry.php
+++ b/src/EventEntry.php
@@ -18,7 +18,7 @@ final class EventEntry implements JsonSerializable
 {
     /**
      * @param ContextData      $context
-     * @param list<EventEntry> $close Child closes (zero or more) — immediate nested close entries in the order their opens closed.
+     * @param list<EventEntry> $close   Child closes (zero or more) — immediate nested close entries in the order their opens closed.
      */
     public function __construct(
         public readonly string $id,

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -9,13 +9,25 @@ use Override;
 
 use function array_map;
 
-final class LogJson implements JsonSerializable
+/**
+ * @psalm-import-type CloseByOpenIdMap from Types
+ * @psalm-import-type EventEntryList from Types
+ * @psalm-import-type EventsByOpenIdMap from Types
+ * @psalm-import-type LogSessionArray from Types
+ * @psalm-import-type OpenCloseEntryList from Types
+ * @psalm-import-type OperationIdSet from Types
+ * @psalm-import-type PublicCloseEntry from Types
+ * @psalm-import-type PublicEventEntry from Types
+ * @psalm-import-type PublicOpenEntry from Types
+ * @psalm-import-type SchemaLinks from Types
+ */
+final class phpLogJson implements JsonSerializable
 {
     /**
-     * @param list<OpenCloseEntry>                                                  $open   Top-level opens (one or more) in chronological order.
-     * @param list<EventEntry>                                                      $close  Internal close entries; matched closes are nested during public serialization.
-     * @param list<EventEntry>                                                      $events
-     * @param list<array{rel: string, href: string, title?: string, type?: string}> $links
+     * @param OpenCloseEntryList $open Top-level opens (one or more) in chronological order.
+     * @param EventEntryList     $close Internal close entries; matched closes are nested during public serialization.
+     * @param EventEntryList     $events
+     * @param SchemaLinks        $links
      */
     public function __construct(
         public readonly string $schemaUrl,
@@ -26,14 +38,14 @@ final class LogJson implements JsonSerializable
     ) {
     }
 
-    /** @return array<string, mixed> Public tree JSON representation */
+    /** @return LogSessionArray Public tree JSON representation */
     #[Override]
     public function jsonSerialize(): array
     {
         return $this->toArray();
     }
 
-    /** @return array<string, mixed> */
+    /** @return LogSessionArray */
     public function toArray(): array
     {
         $closeByOpenId = [];
@@ -73,17 +85,17 @@ final class LogJson implements JsonSerializable
         return $result;
     }
 
-    /** @return array<string, mixed> */
+    /** @return LogSessionArray */
     public function toTreeArray(): array
     {
         return $this->toArray();
     }
 
     /**
-     * @param array<string, EventEntry>       $closeByOpenId
-     * @param array<string, list<EventEntry>> $eventsByOpenId
+     * @param CloseByOpenIdMap $closeByOpenId
+     * @param EventsByOpenIdMap $eventsByOpenId
      *
-     * @return array<string, mixed>
+     * @return PublicOpenEntry
      */
     private function buildTreeOpenEntry(OpenCloseEntry $entry, array $closeByOpenId, array $eventsByOpenId): array
     {
@@ -116,10 +128,10 @@ final class LogJson implements JsonSerializable
     }
 
     /**
-     * @param list<EventEntry>          $closes
-     * @param array<string, true>       $openIds
+     * @param EventEntryList  $closes
+     * @param array<string, true> $openIds
      * @param array<string, EventEntry> $closeByOpenId
-     * @param list<EventEntry>          $orphanCloses
+     * @param list<EventEntry> $orphanCloses
      */
     private function partitionCloses(array $closes, array $openIds, array &$closeByOpenId, array &$orphanCloses): void
     {
@@ -143,9 +155,9 @@ final class LogJson implements JsonSerializable
     }
 
     /**
-     * @param list<EventEntry> $events
+     * @param EventEntryList $events
      *
-     * @return array<string, list<EventEntry>>
+     * @return EventsByOpenIdMap
      */
     private function groupEventsByOpenId(array $events): array
     {
@@ -158,8 +170,8 @@ final class LogJson implements JsonSerializable
     }
 
     /**
-     * @param list<OpenCloseEntry> $entries
-     * @param array<string, true>  $openIds
+     * @param OpenCloseEntryList $entries
+     * @param array<string, true> $openIds
      */
     private function collectOpenIds(array $entries, array &$openIds): void
     {
@@ -175,7 +187,7 @@ final class LogJson implements JsonSerializable
     /**
      * @param array<string, true> $openIds
      *
-     * @return list<EventEntry>
+     * @return EventEntryList
      */
     private function topLevelTreeEvents(array $openIds): array
     {
@@ -190,7 +202,7 @@ final class LogJson implements JsonSerializable
         return $topLevelEvents;
     }
 
-    /** @return array<string, mixed> */
+    /** @return PublicCloseEntry */
     private function closeToArray(EventEntry $close, bool $includeOpenId): array
     {
         $result = [
@@ -211,7 +223,7 @@ final class LogJson implements JsonSerializable
         return $result;
     }
 
-    /** @return array<string, mixed> */
+    /** @return PublicEventEntry */
     private function eventToArray(EventEntry $event, bool $includeOpenId): array
     {
         $result = [

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -21,11 +21,11 @@ use function array_map;
  * @psalm-import-type PublicOpenEntry from Types
  * @psalm-import-type SchemaLinks from Types
  */
-final class phpLogJson implements JsonSerializable
+final class LogJson implements JsonSerializable
 {
     /**
-     * @param OpenCloseEntryList $open Top-level opens (one or more) in chronological order.
-     * @param EventEntryList     $close Internal close entries; matched closes are nested during public serialization.
+     * @param OpenCloseEntryList $open   Top-level opens (one or more) in chronological order.
+     * @param EventEntryList     $close  Internal close entries; matched closes are nested during public serialization.
      * @param EventEntryList     $events
      * @param SchemaLinks        $links
      */
@@ -92,7 +92,7 @@ final class phpLogJson implements JsonSerializable
     }
 
     /**
-     * @param CloseByOpenIdMap $closeByOpenId
+     * @param CloseByOpenIdMap  $closeByOpenId
      * @param EventsByOpenIdMap $eventsByOpenId
      *
      * @return PublicOpenEntry
@@ -128,10 +128,10 @@ final class phpLogJson implements JsonSerializable
     }
 
     /**
-     * @param EventEntryList  $closes
-     * @param array<string, true> $openIds
+     * @param EventEntryList            $closes
+     * @param array<string, true>       $openIds
      * @param array<string, EventEntry> $closeByOpenId
-     * @param list<EventEntry> $orphanCloses
+     * @param list<EventEntry>          $orphanCloses
      */
     private function partitionCloses(array $closes, array $openIds, array &$closeByOpenId, array &$orphanCloses): void
     {
@@ -170,7 +170,7 @@ final class phpLogJson implements JsonSerializable
     }
 
     /**
-     * @param OpenCloseEntryList $entries
+     * @param OpenCloseEntryList  $entries
      * @param array<string, true> $openIds
      */
     private function collectOpenIds(array $entries, array &$openIds): void

--- a/src/OpenCloseEntry.php
+++ b/src/OpenCloseEntry.php
@@ -9,11 +9,15 @@ use Override;
 
 use function array_map;
 
+/**
+ * @psalm-import-type ContextData from Types
+ * @psalm-import-type OpenCloseEntryArray from Types
+ */
 final class OpenCloseEntry implements JsonSerializable
 {
     /**
-     * @param array<string, mixed> $context
-     * @param list<OpenCloseEntry> $open    Child opens (zero or more) — immediate nested operations in chronological order.
+     * @param ContextData          $context
+     * @param list<OpenCloseEntry> $open Child opens (zero or more) — immediate nested operations in chronological order.
      */
     public function __construct(
         public readonly string $id,
@@ -25,7 +29,7 @@ final class OpenCloseEntry implements JsonSerializable
     ) {
     }
 
-    /** @return array<string, mixed> */
+    /** @return OpenCloseEntryArray */
     public function toArray(): array
     {
         $result = [

--- a/src/OpenCloseEntry.php
+++ b/src/OpenCloseEntry.php
@@ -17,7 +17,7 @@ final class OpenCloseEntry implements JsonSerializable
 {
     /**
      * @param ContextData          $context
-     * @param list<OpenCloseEntry> $open Child opens (zero or more) — immediate nested operations in chronological order.
+     * @param list<OpenCloseEntry> $open    Child opens (zero or more) — immediate nested operations in chronological order.
      */
     public function __construct(
         public readonly string $id,

--- a/src/Profiler/OperationProfile.php
+++ b/src/Profiler/OperationProfile.php
@@ -7,6 +7,10 @@ namespace Koriym\SemanticLogger\Profiler;
 use JsonSerializable;
 use Override;
 
+/**
+ * @psalm-import-type OperationProfileData from \Koriym\SemanticLogger\Types
+ * @psalm-import-type ProfileArtifact from \Koriym\SemanticLogger\Types
+ */
 final class OperationProfile implements JsonSerializable
 {
     /**
@@ -22,7 +26,7 @@ final class OperationProfile implements JsonSerializable
     ) {
     }
 
-    /** @return array<string, mixed> */
+    /** @return OperationProfileData */
     #[Override]
     public function jsonSerialize(): array
     {
@@ -48,7 +52,7 @@ final class OperationProfile implements JsonSerializable
         return $this->serializeXdebugTraceSegments() !== [] || $this->serializeXhprofProfileSegments() !== [];
     }
 
-    /** @return list<array{path: string}> */
+    /** @return list<ProfileArtifact> */
     private function serializeXdebugTraceSegments(): array
     {
         $result = [];
@@ -64,7 +68,7 @@ final class OperationProfile implements JsonSerializable
         return $result;
     }
 
-    /** @return list<array{path: string}> */
+    /** @return list<ProfileArtifact> */
     private function serializeXhprofProfileSegments(): array
     {
         $result = [];

--- a/src/Profiler/OperationProfile.php
+++ b/src/Profiler/OperationProfile.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Koriym\SemanticLogger\Profiler;
 
 use JsonSerializable;
+use Koriym\SemanticLogger\Types;
 use Override;
 
 /**
- * @psalm-import-type OperationProfileData from \Koriym\SemanticLogger\Types
- * @psalm-import-type ProfileArtifact from \Koriym\SemanticLogger\Types
+ * @psalm-import-type OperationProfileData from Types
+ * @psalm-import-type ProfileArtifact from Types
  */
 final class OperationProfile implements JsonSerializable
 {

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -16,23 +16,32 @@ use function assert;
 use function is_array;
 use function is_string;
 
+/**
+ * @psalm-import-type ContextData from Types
+ * @psalm-import-type EventEntryList from Types
+ * @psalm-import-type LogSessionArray from Types
+ * @psalm-import-type OpenChildrenByParent from Types
+ * @psalm-import-type OpenCloseEntryList from Types
+ * @psalm-import-type SchemaLinks from Types
+ * @psalm-import-type TypeCounts from Types
+ */
 final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 {
     private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
 
-    /** @var list<EventEntry> */
+    /** @var EventEntryList */
     private array $events = [];
 
     /** @var SplStack<OpenCloseEntry> */
     private SplStack $openStack;
 
-    /** @var list<EventEntry> Close entries in chronological close order. */
+    /** @var EventEntryList Close entries in chronological close order. */
     private array $closeLog = [];
 
-    /** @var list<OpenCloseEntry> Completed opens in chronological close order; each carries the parentId captured at open time. */
+    /** @var OpenCloseEntryList Completed opens in chronological close order; each carries the parentId captured at open time. */
     private array $completedOperations = [];
 
-    /** @var array<string, int> */
+    /** @var TypeCounts */
     private array $typeCounts = [];
 
     public function __construct()
@@ -132,13 +141,13 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         return $this->createLogJson()->toArray();
     }
 
-    /** @return array<string, mixed> */
+    /** @return LogSessionArray */
     public function toArray(): array
     {
         return $this->createLogJson()->toArray();
     }
 
-    /** @param list<array{rel: string, href: string, title?: string, type?: string}> $links */
+    /** @param SchemaLinks $links */
     #[Override]
     public function flush(array $links = []): LogJson
     {
@@ -206,7 +215,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
      * under their parent and appear in chronological close order (which equals
      * open order for correctly-nested LIFO sessions).
      *
-     * @return list<OpenCloseEntry>
+     * @return OpenCloseEntryList
      */
     private function buildNestedOpen(): array
     {
@@ -216,9 +225,9 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     }
 
     /**
-     * @param array<string, list<OpenCloseEntry>> $childrenByParent
+     * @param OpenChildrenByParent $childrenByParent
      *
-     * @return list<OpenCloseEntry>
+     * @return OpenCloseEntryList
      */
     private function buildOpenChildren(string|null $parentId, array $childrenByParent): array
     {
@@ -248,7 +257,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
      * Closes are still tracked by openId internally even though the public JSON
      * serializer nests matched closes directly under their open node.
      *
-     * @return list<EventEntry>
+     * @return EventEntryList
      */
     private function buildNestedClose(): array
     {
@@ -264,10 +273,10 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     }
 
     /**
-     * @param array<string, list<OpenCloseEntry>> $childrenByParent
-     * @param array<string, EventEntry>           $closeByOpenId
+     * @param OpenChildrenByParent $childrenByParent
+     * @param array<string, EventEntry> $closeByOpenId
      *
-     * @return list<EventEntry>
+     * @return EventEntryList
      */
     private function buildCloseChildren(string|null $parentId, array $childrenByParent, array $closeByOpenId): array
     {
@@ -297,7 +306,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         return $result;
     }
 
-    /** @return array<string, list<OpenCloseEntry>> */
+    /** @return OpenChildrenByParent */
     private function groupByParent(): array
     {
         $childrenByParent = [];
@@ -317,7 +326,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
      * to satisfy `{}` schemas) retain control. Falls back to `(array)` cast for
      * legacy contexts that rely on public-property introspection.
      *
-     * @return array<string, mixed>
+     * @return ContextData
      */
     private function contextToArray(AbstractContext $context): array
     {
@@ -325,12 +334,12 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
             /** @var mixed $serialized */
             $serialized = $context->jsonSerialize();
             if (is_array($serialized)) {
-                /** @var array<string, mixed> $serialized */
+                /** @var ContextData $serialized */
                 return $serialized;
             }
         }
 
-        /** @var array<string, mixed> $mixedArray */
+        /** @var ContextData $mixedArray */
         $mixedArray = (array) $context;
 
         return $mixedArray;

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -273,7 +273,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     }
 
     /**
-     * @param OpenChildrenByParent $childrenByParent
+     * @param OpenChildrenByParent      $childrenByParent
      * @param array<string, EventEntry> $closeByOpenId
      *
      * @return EventEntryList

--- a/src/SemanticLoggerInterface.php
+++ b/src/SemanticLoggerInterface.php
@@ -4,14 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\SemanticLogger;
 
-/**
- * @psalm-import-type SchemaLinks from Types
- *
- * Semantic Logger Interface for hierarchical structured logging
- *
- * Provides type-safe logging with JSON schema validation for complex application workflows.
- * Supports open/event/close patterns for tracking nested operations.
- */
+/** @psalm-import-type SchemaLinks from Types */
 interface SemanticLoggerInterface
 {
     /**

--- a/src/SemanticLoggerInterface.php
+++ b/src/SemanticLoggerInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Koriym\SemanticLogger;
 
 /**
+ * @psalm-import-type SchemaLinks from Types
+ *
  * Semantic Logger Interface for hierarchical structured logging
  *
  * Provides type-safe logging with JSON schema validation for complex application workflows.
@@ -48,7 +50,7 @@ interface SemanticLoggerInterface
      * the internal state for the next logging session. This implements the
      * flush pattern for one-time log consumption.
      *
-     * @param list<array{rel: string, href: string, title?: string, type?: string}> $links Optional links for complete system transparency
+     * @param SchemaLinks $links Optional links for complete system transparency
      */
     public function flush(array $links = []): LogJson;
 }

--- a/src/Types.php
+++ b/src/Types.php
@@ -5,17 +5,20 @@ declare(strict_types=1);
 namespace Koriym\SemanticLogger;
 
 /**
- * Semantic Logger Domain Types
+ * Type definitions for SemanticLogger
  *
- * This file contains all type definitions for the semantic logger system.
- * These types ensure type safety while maintaining flexibility for dynamic log data.
+ * @phpcs:disable SlevomatCodingStandard.Commenting.DocCommentSpacing
+ * @psalm-suppress UnusedClass
  *
- * Core data types:
- *
+ * Core scalar and map types
  * @psalm-type ContextData = array<string, mixed>
+ * @psalm-type JsonMap = array<string, mixed>
  * @psalm-type SchemaUrl = string
  * @psalm-type LogType = string
+ * @psalm-type OperationId = string
  * @psalm-type RelationType = string
+ *
+ * Link types
  * @psalm-type SchemaLink = array{
  *     rel: RelationType,
  *     href: SchemaUrl,
@@ -23,27 +26,80 @@ namespace Koriym\SemanticLogger;
  *     type?: string
  * }
  * @psalm-type SchemaLinks = list<SchemaLink>
+ *
+ * Profiling types
+ * @psalm-type ProfileArtifact = array{path: string}
+ * @psalm-type OperationProfileData = array{
+ *     wallTime: float,
+ *     xdebugTrace?: list<ProfileArtifact>,
+ *     xhprofProfile?: list<ProfileArtifact>
+ * }
+ * @psalm-type WallTimesByOperationId = array<OperationId, float>
+ * @psalm-type XdebugSegmentsByOperationId = array<OperationId, list<Profiler\XdebugTrace>>
+ * @psalm-type XhprofSegmentsByOperationId = array<OperationId, list<Profiler\XHProfResult>>
+ * @psalm-type OperationProfilesById = array<OperationId, Profiler\OperationProfile>
+ *
+ * Runtime collection types
+ * @psalm-type EventEntryList = list<EventEntry>
+ * @psalm-type OpenCloseEntryList = list<OpenCloseEntry>
+ * @psalm-type OpenChildrenByParent = array<string, list<OpenCloseEntry>>
+ * @psalm-type CloseByOpenIdMap = array<string, EventEntry>
+ * @psalm-type EventsByOpenIdMap = array<string, list<EventEntry>>
+ * @psalm-type OperationIdSet = array<OperationId, true>
+ * @psalm-type TypeCounts = array<LogType, int>
+ * @psalm-type SchemaTypeMap = array<LogType, string>
+ *
+ * Serialized log entry types
  * @psalm-type EventEntryArray = array{
  *     type: LogType,
- *     '$schema': SchemaUrl,
- *     context: ContextData
+ *     id: OperationId,
+ *     schemaUrl: SchemaUrl,
+ *     context: ContextData,
+ *     openId?: OperationId,
+ *     close?: list<JsonMap>,
+ *     profile?: OperationProfileData
  * }
  * @psalm-type OpenCloseEntryArray = array{
  *     type: LogType,
- *     '$schema': SchemaUrl,
+ *     id: OperationId,
+ *     schemaUrl: SchemaUrl,
  *     context: ContextData,
- *     open?: array<string, mixed>
+ *     open?: list<JsonMap>
  * }
- * @psalm-type CloseEntryArray = EventEntryArray
+ * @psalm-type PublicEventEntry = array{
+ *     type: LogType,
+ *     id: OperationId,
+ *     schemaUrl: SchemaUrl,
+ *     context: ContextData,
+ *     openId?: OperationId
+ * }
+ * @psalm-type PublicCloseEntry = array{
+ *     type: LogType,
+ *     id: OperationId,
+ *     schemaUrl: SchemaUrl,
+ *     context: ContextData,
+ *     openId?: OperationId,
+ *     profile?: OperationProfileData
+ * }
+ * @psalm-type PublicOpenEntry = array{
+ *     type: LogType,
+ *     id: OperationId,
+ *     schemaUrl: SchemaUrl,
+ *     context: ContextData,
+ *     events?: list<PublicEventEntry>,
+ *     close?: PublicCloseEntry,
+ *     open?: list<JsonMap>
+ * }
+ * @psalm-type CloseEntryArray = PublicCloseEntry
  * @psalm-type LogSessionArray = array{
  *     '$schema': SchemaUrl,
- *     open: OpenCloseEntryArray,
- *     events?: list<EventEntryArray>,
- *     close?: CloseEntryArray,
+ *     open: list<PublicOpenEntry>,
+ *     events?: list<PublicEventEntry>,
+ *     close?: array<array-key, PublicCloseEntry>,
  *     links?: SchemaLinks
  * }
- * @psalm-type EventEntryList = list<EventEntry>
- * @psalm-type OpenCloseEntryStack = list<OpenCloseEntry>
+ *
+ * MCP types
  * @psalm-type McpJsonRpcError = array{
  *     code: int,
  *     message: string
@@ -102,14 +158,19 @@ namespace Koriym\SemanticLogger;
  * }
  * @psalm-type McpToolCallParams = array{
  *     name: string,
- *     arguments?: array<string, mixed>
+ *     arguments?: JsonMap
  * }
  * @psalm-type McpSemanticAnalyzeArgs = array{
  *     script?: string,
  *     xdebug_mode?: string
  * }
- * @psalm-type McpLogData = array<string, mixed>
+ * @psalm-type McpLogData = JsonMap
+ * @phpcs:enable
  */
 final class Types
 {
+    /** @codeCoverageIgnore */
+    private function __construct()
+    {
+    }
 }

--- a/tests/OpenCloseEntryTest.php
+++ b/tests/OpenCloseEntryTest.php
@@ -70,9 +70,11 @@ final class OpenCloseEntryTest extends TestCase
         $this->assertSame('parent_entry_1', $entry->open[0]->parentId);
 
         $array = $entry->toArray();
-        $this->assertArrayHasKey('open', $array);
+        if (! isset($array['open'])) {
+            self::fail('Serialized parent entry should contain open children.');
+        }
+
         $openArray = $array['open'];
-        $this->assertIsArray($openArray);
         $this->assertCount(2, $openArray);
     }
 
@@ -97,11 +99,17 @@ final class OpenCloseEntryTest extends TestCase
 
         // Test array serialization - level3 should not have nested open
         $array = $level1->toArray();
-        $this->assertArrayHasKey('open', $array);
+        if (! isset($array['open'])) {
+            self::fail('Level1 entry should contain serialized children.');
+        }
+
         /** @var list<array<string, mixed>> $level2List */
         $level2List = $array['open'];
         $level2Array = $level2List[0];
-        $this->assertArrayHasKey('open', $level2Array);
+        if (! isset($level2Array['open'])) {
+            self::fail('Level2 entry should contain serialized children.');
+        }
+
         /** @var list<array<string, mixed>> $level3List */
         $level3List = $level2Array['open'];
         $level3Array = $level3List[0];

--- a/tests/SemanticLoggerTest.php
+++ b/tests/SemanticLoggerTest.php
@@ -457,7 +457,10 @@ final class SemanticLoggerTest extends TestCase
         $this->assertSame('https://example.com/db/schema/users.sql', $logJson->links[0]['href']);
 
         $logArray = $logJson->toArray();
-        $this->assertArrayHasKey('links', $logArray);
+        if (! isset($logArray['links'])) {
+            self::fail('Serialized log should contain relation links.');
+        }
+
         /** @var list<array{rel: string, href: string, title?: string, type?: string}> $links */
         $links = $logArray['links'];
         $this->assertCount(3, $links);
@@ -525,7 +528,10 @@ final class SemanticLoggerTest extends TestCase
         $root = $this->serializedOpenEntries($logArray)[0];
         $events = $this->serializedEntryEvents($root);
         $this->assertArrayNotHasKey('events', $logArray);
-        $this->assertArrayHasKey('links', $logArray);
+        if (! isset($logArray['links'])) {
+            self::fail('Serialized log should contain relation links.');
+        }
+
         $this->assertCount(1, $events);
         $this->assertSame('processing step', $this->serializedEntryContext($events[0])['message']);
 


### PR DESCRIPTION
## What changed
- normalized the SemanticLogger type catalog around shared domain aliases in `src/Types.php`
- replaced repeated array-shape annotations with imported aliases across the core logger classes
- adjusted tests to respect optional serialized keys
- added a reusable `php-domain-types` skill for introducing and organizing domain type aliases in PHP projects

## Why
The project already benefited from shared type aliases, but the usage pattern was still uneven and repetitive. This change makes the domain vocabulary explicit, keeps the alias catalog closer to the `Ray.Di` / `Ray.Aop` style, and captures the workflow as a reusable skill.

## Impact
- domain-oriented Psalm aliases are easier to discover and reuse
- static-analysis intent is clearer in the logger and serialization paths
- the new skill can be reused when similar alias refactors are needed in other PHP codebases

## Validation
- `XDG_CACHE_HOME=/tmp vendor/bin/psalm --show-info=false --threads=1`
- `vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=512M`
- `composer test`

## Notes
- the isolated PR branch has the same tree as the validated branch used during implementation
- existing `vendor-bin/*/composer.lock` worktree changes were intentionally excluded from this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced PHP Domain Types skill guide for identifying and organizing reusable type shapes in PHP codebases
  * Added OpenAI skill interface for introducing and normalizing domain type aliases

* **Documentation**
  * New naming patterns reference for domain type alias conventions and best practices

* **Tests**
  * Enhanced test assertions with explicit validation checks for improved error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->