### PR TITLE
Fix SemanticLogValidator: empty object false negative and missing root envelope check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,12 @@
 # Exclude build/test files from archive
 /tests            export-ignore
 /demo             export-ignore
-/docs             export-ignore
+/docs/css         export-ignore
+/docs/images      export-ignore
+/docs/stree       export-ignore
+/docs/*.html      export-ignore
+/docs/*.md        export-ignore
+/docs/*.txt       export-ignore
 /scripts          export-ignore
 /build            export-ignore
 /vendor-bin       export-ignore

--- a/src/SemanticLogValidator.php
+++ b/src/SemanticLogValidator.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 use JsonSchema\Validator;
 use Override;
 use RuntimeException;
-use stdClass;
 
 use function basename;
 use function count;
@@ -19,7 +18,6 @@ use function is_array;
 use function is_object;
 use function is_string;
 use function json_decode;
-use function json_encode;
 use function property_exists;
 use function realpath;
 use function sprintf;
@@ -55,7 +53,7 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
             throw new InvalidArgumentException('Log data must be an object');
         }
 
-        $this->validateRootSchema($logData, $schemaDir, $violations);
+        $this->validateRootSchema($logData, $violations);
         $this->validateContexts($logData, $schemaDir, $violations);
 
         if (! empty($violations)) {
@@ -245,9 +243,14 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
      *
      * @param-out list<string> $violations
      */
-    private function validateRootSchema(object $logData, string $schemaDir, array &$violations): void
+    private function validateRootSchema(object $logData, array &$violations): void
     {
-        $schema = $this->loadRootSchema($schemaDir, $violations);
+        $schemaFile = dirname(__DIR__) . '/docs/schemas/semantic-log.json';
+        if (! file_exists($schemaFile)) {
+            throw new RuntimeException("Bundled semantic-log schema not found: {$schemaFile}");
+        }
+
+        $schema = $this->loadSchema($schemaFile, 'root', $violations);
         if ($schema === null) {
             return;
         }
@@ -255,46 +258,19 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
         $validator = new Validator();
         $validator->validate($logData, $schema);
 
-        if (! $validator->isValid()) {
-            foreach ($validator->getErrors() as $error) {
-                if (! is_array($error)) {
-                    continue;
-                }
+        if ($validator->isValid()) {
+            return;
+        }
 
-                $property = isset($error['property']) && is_string($error['property']) ? $error['property'] : '';
-                $message = isset($error['message']) && is_string($error['message']) ? $error['message'] : 'Validation failed';
-                $violations[] = "[root] {$message} at '{$property}'";
+        foreach ($validator->getErrors() as $error) {
+            if (! is_array($error)) {
+                continue;
             }
+
+            $property = isset($error['property']) && is_string($error['property']) ? $error['property'] : '';
+            $message = isset($error['message']) && is_string($error['message']) ? $error['message'] : 'Validation failed';
+            $violations[] = "[root] {$message} at '{$property}'";
         }
-    }
-
-    /**
-     * @param list<string> $violations
-     *
-     * @param-out list<string> $violations
-     */
-    private function loadRootSchema(string $schemaDir, array &$violations): object|null
-    {
-        $staticSchemaFile = dirname(__DIR__) . '/docs/schemas/semantic-log.json';
-        if (file_exists($staticSchemaFile)) {
-            return $this->loadSchema($staticSchemaFile, 'root', $violations);
-        }
-
-        $schemaJson = json_encode((new DynamicSchemaGenerator($schemaDir))->generateCombinedSchema());
-        if ($schemaJson === false) {
-            $violations[] = '[root] Failed to encode generated root schema';
-
-            return null;
-        }
-
-        $schema = json_decode($schemaJson);
-        if (! $schema instanceof stdClass) {
-            $violations[] = '[root] Failed to decode generated root schema';
-
-            return null;
-        }
-
-        return $schema;
     }
 
     /**

--- a/src/SemanticLogValidator.php
+++ b/src/SemanticLogValidator.php
@@ -8,15 +8,19 @@ use InvalidArgumentException;
 use JsonSchema\Validator;
 use Override;
 use RuntimeException;
+use stdClass;
 
 use function basename;
 use function count;
+use function dirname;
 use function file_exists;
 use function file_get_contents;
 use function is_array;
+use function is_object;
 use function is_string;
 use function json_decode;
 use function json_encode;
+use function property_exists;
 use function realpath;
 use function sprintf;
 use function str_contains;
@@ -40,18 +44,18 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
             throw new InvalidArgumentException("Cannot read log file: {$file}");
         }
 
-        $logData = json_decode($contents, true);
+        $logData = json_decode($contents);
         if ($logData === null) {
             throw new InvalidArgumentException("Invalid JSON in log file: {$file}");
         }
 
         $violations = [];
 
-        // Validate all contexts recursively
-        if (! is_array($logData)) {
-            throw new InvalidArgumentException('Log data must be an array');
+        if (! is_object($logData)) {
+            throw new InvalidArgumentException('Log data must be an object');
         }
 
+        $this->validateRootSchema($logData, $schemaDir, $violations);
         $this->validateContexts($logData, $schemaDir, $violations);
 
         if (! empty($violations)) {
@@ -66,48 +70,44 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
     /**
      * Extract and validate all contexts from log data
      *
-     * @param array<mixed> $data
      * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function validateContexts(array $data, string $schemaDir, array &$violations): void
+    private function validateContexts(object $data, string $schemaDir, array &$violations): void
     {
-        if (isset($data['open']) && is_array($data['open'])) {
+        if (isset($data->open) && is_array($data->open)) {
             /** @var array<int, mixed> $opens */
-            $opens = $data['open'];
+            $opens = $data->open;
             foreach ($opens as $index => $open) {
-                if (! is_array($open)) {
+                if (! is_object($open)) {
                     continue;
                 }
 
-                /** @var array<string, mixed> $open */
                 $this->validateOpenEntry($open, $schemaDir, "open[{$index}]", $violations);
             }
         }
 
-        if (isset($data['close']) && is_array($data['close'])) {
+        if (isset($data->close) && is_array($data->close)) {
             /** @var array<int, mixed> $closes */
-            $closes = $data['close'];
+            $closes = $data->close;
             foreach ($closes as $index => $close) {
-                if (! is_array($close)) {
+                if (! is_object($close)) {
                     continue;
                 }
 
-                /** @var array<string, mixed> $close */
                 $this->validateCloseEntry($close, $schemaDir, "close[{$index}]", $violations);
             }
         }
 
-        if (isset($data['events']) && is_array($data['events'])) {
+        if (isset($data->events) && is_array($data->events)) {
             /** @var array<int, mixed> $events */
-            $events = $data['events'];
+            $events = $data->events;
             foreach ($events as $index => $event) {
-                if (! is_array($event)) {
+                if (! is_object($event)) {
                     continue;
                 }
 
-                /** @var array<string, mixed> $event */
                 $this->validateEventEntry($event, $schemaDir, "events[{$index}]", $violations);
             }
         }
@@ -116,31 +116,35 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
     /**
      * Validate a single context against its schema
      *
-     * @param array<string, mixed> $contextData
-     * @param list<string>         $violations
+     * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function validateContext(array $contextData, string $schemaDir, string $path, array &$violations): void
+    private function validateContext(object $contextData, string $schemaDir, string $path, array &$violations): void
     {
         $schemaUrl = $this->extractSchemaUrl($contextData);
-        if ($schemaUrl !== null && isset($contextData['context'], $contextData['type'])) {
+        if ($schemaUrl !== null && isset($contextData->context, $contextData->type)) {
             $this->validateSingleContext($contextData, $schemaUrl, $schemaDir, $path, $violations);
         }
     }
 
     /**
-     * @param array<string, mixed> $contextData
-     * @param list<string>         $violations
+     * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function validateSingleContext(array $contextData, string $schemaUrl, string $schemaDir, string $path, array &$violations): void
+    private function validateSingleContext(object $contextData, string $schemaUrl, string $schemaDir, string $path, array &$violations): void
     {
-        $type = $contextData['type'];
-        $context = $contextData['context'];
+        if (! property_exists($contextData, 'type') || ! property_exists($contextData, 'context')) {
+            $violations[] = "[{$path}] Invalid context structure";
 
-        if (! is_string($type) || ! is_array($context)) {
+            return;
+        }
+
+        $type = $contextData->type;
+        $context = $contextData->context;
+
+        if (! is_string($type) || ! is_object($context)) {
             $violations[] = "[{$path}] Invalid context structure";
 
             return;
@@ -161,15 +165,14 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
         $this->performValidation($context, $schema, $type, $schemaUrl, $path, $violations);
     }
 
-    /** @param array<string, mixed> $contextData */
-    private function extractSchemaUrl(array $contextData): string|null
+    private function extractSchemaUrl(object $contextData): string|null
     {
-        if (isset($contextData['$schema']) && is_string($contextData['$schema'])) {
-            return $contextData['$schema'];
+        if (property_exists($contextData, '$schema') && is_string($contextData->{'$schema'})) {
+            return $contextData->{'$schema'};
         }
 
-        if (isset($contextData['schemaUrl']) && is_string($contextData['schemaUrl'])) {
-            return $contextData['schemaUrl'];
+        if (isset($contextData->schemaUrl) && is_string($contextData->schemaUrl)) {
+            return $contextData->schemaUrl;
         }
 
         return null;
@@ -201,24 +204,14 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
     }
 
     /**
-     * @param array<mixed> $context
      * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function performValidation(array $context, object $schema, string $type, string $schemaUrl, string $path, array &$violations): void
+    private function performValidation(object $context, object $schema, string $type, string $schemaUrl, string $path, array &$violations): void
     {
         $validator = new Validator();
-        $contextJson = json_encode($context);
-        if ($contextJson === false) {
-            $violations[] = "[{$path}] Failed to encode context to JSON";
-
-            return;
-        }
-
-        /** @var object|null $contextObj */
-        $contextObj = json_decode($contextJson);
-        $validator->validate($contextObj, $schema);
+        $validator->validate($context, $schema);
 
         if (! $validator->isValid()) {
             $this->addValidationErrors($validator, $type, $path, $violations);
@@ -248,66 +241,117 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
     }
 
     /**
-     * @param array<string, mixed> $entry
-     * @param list<string>         $violations
+     * @param list<string> $violations
      *
-     * @param-out list<string>    $violations
+     * @param-out list<string> $violations
      */
-    private function validateOpenEntry(array $entry, string $schemaDir, string $path, array &$violations): void
+    private function validateRootSchema(object $logData, string $schemaDir, array &$violations): void
     {
-        $this->validateContext($entry, $schemaDir, $path, $violations);
+        $schema = $this->loadRootSchema($schemaDir, $violations);
+        if ($schema === null) {
+            return;
+        }
 
-        if (isset($entry['events']) && is_array($entry['events'])) {
-            /** @var array<int, mixed> $events */
-            $events = $entry['events'];
-            foreach ($events as $index => $event) {
-                if (! is_array($event)) {
+        $validator = new Validator();
+        $validator->validate($logData, $schema);
+
+        if (! $validator->isValid()) {
+            foreach ($validator->getErrors() as $error) {
+                if (! is_array($error)) {
                     continue;
                 }
 
-                /** @var array<string, mixed> $event */
+                $property = isset($error['property']) && is_string($error['property']) ? $error['property'] : '';
+                $message = isset($error['message']) && is_string($error['message']) ? $error['message'] : 'Validation failed';
+                $violations[] = "[root] {$message} at '{$property}'";
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $violations
+     *
+     * @param-out list<string> $violations
+     */
+    private function loadRootSchema(string $schemaDir, array &$violations): object|null
+    {
+        $staticSchemaFile = dirname(__DIR__) . '/docs/schemas/semantic-log.json';
+        if (file_exists($staticSchemaFile)) {
+            return $this->loadSchema($staticSchemaFile, 'root', $violations);
+        }
+
+        $schemaJson = json_encode((new DynamicSchemaGenerator($schemaDir))->generateCombinedSchema());
+        if ($schemaJson === false) {
+            $violations[] = '[root] Failed to encode generated root schema';
+
+            return null;
+        }
+
+        $schema = json_decode($schemaJson);
+        if (! $schema instanceof stdClass) {
+            $violations[] = '[root] Failed to decode generated root schema';
+
+            return null;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param list<string> $violations
+     *
+     * @param-out list<string>    $violations
+     */
+    private function validateOpenEntry(object $entry, string $schemaDir, string $path, array &$violations): void
+    {
+        $this->validateContext($entry, $schemaDir, $path, $violations);
+
+        if (isset($entry->events) && is_array($entry->events)) {
+            /** @var array<int, mixed> $events */
+            $events = $entry->events;
+            foreach ($events as $index => $event) {
+                if (! is_object($event)) {
+                    continue;
+                }
+
                 $this->validateEventEntry($event, $schemaDir, "{$path}.events[{$index}]", $violations);
             }
         }
 
-        if (isset($entry['close']) && is_array($entry['close'])) {
-            /** @var array<string, mixed> $close */
-            $close = $entry['close'];
+        if (isset($entry->close) && is_object($entry->close)) {
+            $close = $entry->close;
             $this->validateCloseEntry($close, $schemaDir, "{$path}.close", $violations);
         }
 
-        if (isset($entry['open']) && is_array($entry['open'])) {
+        if (isset($entry->open) && is_array($entry->open)) {
             /** @var array<int, mixed> $children */
-            $children = $entry['open'];
+            $children = $entry->open;
             foreach ($children as $index => $child) {
-                if (! is_array($child)) {
+                if (! is_object($child)) {
                     continue;
                 }
 
-                /** @var array<string, mixed> $child */
                 $this->validateOpenEntry($child, $schemaDir, "{$path}.open[{$index}]", $violations);
             }
         }
     }
 
     /**
-     * @param array<string, mixed> $entry
-     * @param list<string>         $violations
+     * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function validateEventEntry(array $entry, string $schemaDir, string $path, array &$violations): void
+    private function validateEventEntry(object $entry, string $schemaDir, string $path, array &$violations): void
     {
         $this->validateContext($entry, $schemaDir, $path, $violations);
     }
 
     /**
-     * @param array<string, mixed> $entry
-     * @param list<string>         $violations
+     * @param list<string> $violations
      *
      * @param-out list<string>    $violations
      */
-    private function validateCloseEntry(array $entry, string $schemaDir, string $path, array &$violations): void
+    private function validateCloseEntry(object $entry, string $schemaDir, string $path, array &$violations): void
     {
         $this->validateContext($entry, $schemaDir, $path, $violations);
     }

--- a/tests/SemanticLogValidatorTest.php
+++ b/tests/SemanticLogValidatorTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+use function file_exists;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class SemanticLogValidatorTest extends TestCase
+{
+    private string $fixtureDirectory = '';
+    private string $schemaDirectory = '';
+    private string $logFile = '';
+    private SemanticLogValidator|null $validator = null;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->fixtureDirectory = sys_get_temp_dir() . '/semantic-log-validator-' . uniqid('', true);
+        $this->schemaDirectory = $this->fixtureDirectory . '/schemas';
+        $this->logFile = $this->fixtureDirectory . '/log.json';
+        mkdir($this->schemaDirectory, 0777, true);
+        $this->validator = new SemanticLogValidator();
+
+        file_put_contents(
+            $this->schemaDirectory . '/being-final-open.json',
+            <<<'JSON'
+{
+  "type": "object",
+  "required": ["from", "final", "input", "inject"],
+  "properties": {
+    "from": { "type": "string" },
+    "final": { "type": "string" },
+    "input": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "inject": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}
+JSON,
+        );
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        if (is_dir($this->schemaDirectory)) {
+            unlink($this->schemaDirectory . '/being-final-open.json');
+            rmdir($this->schemaDirectory);
+        }
+
+        if (is_dir($this->fixtureDirectory)) {
+            if (file_exists($this->logFile)) {
+                unlink($this->logFile);
+            }
+
+            rmdir($this->fixtureDirectory);
+        }
+    }
+
+    public function testValidateAcceptsEmptyObjectMapsInContext(): void
+    {
+        file_put_contents(
+            $this->logFile,
+            <<<'JSON'
+{
+  "$schema": "https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json",
+  "open": [
+    {
+      "id": "being_final_open_1",
+      "type": "being_final_open",
+      "schemaUrl": "https://be-framework.org/schemas/being-final-open.json",
+      "context": {
+        "from": "App\\Input\\OrderInput",
+        "final": "App\\Final\\OrderConfirmed",
+        "input": {},
+        "inject": {}
+      }
+    }
+  ]
+}
+JSON,
+        );
+
+        $this->expectOutputRegex('/All contexts validate successfully/');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+
+    public function testValidateRejectsMissingRootSchemaField(): void
+    {
+        file_put_contents(
+            $this->logFile,
+            <<<'JSON'
+{
+  "open": [
+    {
+      "id": "being_final_open_1",
+      "type": "being_final_open",
+      "schemaUrl": "https://be-framework.org/schemas/being-final-open.json",
+      "context": {
+        "from": "App\\Input\\OrderInput",
+        "final": "App\\Final\\OrderConfirmed",
+        "input": {},
+        "inject": {}
+      }
+    }
+  ]
+}
+JSON,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectOutputRegex('/\$schema/');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+
+    public function testValidateRejectsInvalidOperationIdPattern(): void
+    {
+        file_put_contents(
+            $this->logFile,
+            <<<'JSON'
+{
+  "$schema": "https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json",
+  "open": [
+    {
+      "id": "bad-id",
+      "type": "being_final_open",
+      "schemaUrl": "https://be-framework.org/schemas/being-final-open.json",
+      "context": {
+        "from": "App\\Input\\OrderInput",
+        "final": "App\\Final\\OrderConfirmed",
+        "input": {},
+        "inject": {}
+      }
+    }
+  ]
+}
+JSON,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectOutputRegex('/open\[0\]\.id|regex pattern/');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+}


### PR DESCRIPTION
## Summary

- Fix false negative where `json_decode(..., true)` collapsed `{}` into `[]`. The validator now preserves object identity throughout traversal.
- Add root envelope validation against `semantic-log.json`. Missing `\$schema`, invalid `operationId` patterns, and other envelope-level violations that previously passed silently are now caught.
- Update `.gitattributes` so `docs/schemas/` ships in the composer dist. The previous `/docs export-ignore` excluded the bundled schema from `git archive`, which meant composer installs never had it.
- Remove the `DynamicSchemaGenerator` fallback from `loadRootSchema()`. The bundled `docs/schemas/semantic-log.json` is now the single source of truth; if it is missing, we throw `RuntimeException` instead of silently validating against a generated schema with different semantics.

## Background

The validator was effectively a context payload validator, narrower than what the README implied. It also rejected valid logs from be-framework, which intentionally emits empty `input` / `inject` as `{}` via `new stdClass()` — the array round-trip dropped that distinction and produced false negatives against `\"type\": \"object\"` schemas.

## Out of scope

The schema resolver's basename-only URL handling (which breaks hierarchical schema URLs) will be addressed in a follow-up PR.

## Test plan

- [x] \`composer test\` — 234 tests pass
- [x] \`composer sa\` — Psalm clean
- [x] \`composer cs\` — phpcs clean
- [x] Verified \`git archive --worktree-attributes\` now includes \`docs/schemas/semantic-log.json\`
- [x] Added regression tests for empty object context, missing root \`\$schema\`, and invalid \`operationId\` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)