### PR TITLE
Add NullSemanticLogger no-op implementation

### DIFF
--- a/src/NullSemanticLogger.php
+++ b/src/NullSemanticLogger.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use Override;
+
+/**
+ * No-op semantic logger
+ *
+ * A zero-cost {@see SemanticLoggerInterface} for when logging is turned off:
+ * open() returns an empty id (callers treat it as "no close needed"), event()
+ * and close() do nothing, and flush() returns an empty log session. Useful as a
+ * default so instrumentation code can call the logger unconditionally without a
+ * runtime cost when observability is disabled.
+ *
+ * @psalm-import-type SchemaLinks from Types
+ */
+final class NullSemanticLogger implements SemanticLoggerInterface
+{
+    private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
+
+    #[Override]
+    public function open(AbstractContext $context): string
+    {
+        return '';
+    }
+
+    #[Override]
+    public function event(AbstractContext $context): void
+    {
+    }
+
+    #[Override]
+    public function close(AbstractContext $context, string $openId): void
+    {
+    }
+
+    /** @param SchemaLinks $links */
+    #[Override]
+    public function flush(array $links = []): LogJson
+    {
+        return new LogJson(self::SEMANTIC_LOG_SCHEMA_URL, [], [], [], $links);
+    }
+}

--- a/tests/NullSemanticLoggerTest.php
+++ b/tests/NullSemanticLoggerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use PHPUnit\Framework\TestCase;
+
+final class NullSemanticLoggerTest extends TestCase
+{
+    public function testNoOpLoggerProducesAnEmptyLogSession(): void
+    {
+        $logger = new NullSemanticLogger();
+
+        $openId = $logger->open(new FakeContext('open'));
+        $this->assertSame('', $openId, 'open() returns an empty id meaning "no close needed"');
+
+        // event() and close() are no-ops and must not throw or change the (empty) session.
+        $logger->event(new FakeContext('event'));
+        $logger->close(new FakeContext('close'), $openId);
+
+        $log = $logger->flush();
+        $this->assertSame([], $log->open);
+        $this->assertSame([], $log->close);
+        $this->assertSame([], $log->events);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `NullSemanticLogger`, a no-op `SemanticLoggerInterface` implementation.

## Why

Instrumentation code typically calls the logger unconditionally (`open` / `event` / `close` / `flush`). A shared no-op lets a consumer disable observability at **zero runtime cost** — without per-call `if` guards, and without each consumer shipping its own null implementation. (BEAR.QueryRepository currently ships a private copy; this moves it to where it belongs.)

## Behavior

- `open()` returns `''` (callers treat an empty id as "no close needed")
- `event()` / `close()` are no-ops
- `flush()` returns an empty `LogJson` session

## Tests

- `NullSemanticLoggerTest` exercises all four methods (full coverage of the new class).
- `composer cs` / `composer sa` / `composer test` (236 tests) green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `NullSemanticLogger`, a no-operation logger implementation. Provides a null object pattern alternative for scenarios where logging is not required while maintaining compatibility with the standard logger interface.

* **Tests**
  * Added unit tests verifying the no-operation logger correctly produces empty log sessions when logging methods are invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->