### PR TITLE
Add strict and total logging modes for 0.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,6 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '8.1'
           - '8.2'
           - '8.3'
           - '8.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - Unreleased
+## [0.9.0] - Unreleased
 
 ### Added
 - **Strict and total logger modes.** `SemanticLoggerMode::Strict` remains the constructor default; `SemanticLoggerMode::Total` records core-owned placeholders and diagnostic events instead of allowing logging failures to interrupt the caller.
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING — PHP 8.2 is now the minimum supported version.** CI covers PHP 8.2 through 8.5.
 - `flush()` now resets state in both modes whether it returns or throws. `toArray()` and `jsonSerialize()` are explicitly non-destructive snapshots.
 - `NullSemanticLogger::open()` now returns unique `noop_N` ids per session instead of an empty sentinel; `flush()` resets its counter.
-- `koriym/stree` now requires `koriym/semantic-logger ^1.0` because its renderer implements the 1.0 `LogRendererInterface` contract.
+- `koriym/stree` now requires `koriym/semantic-logger ^0.9` because its renderer implements the new `LogRendererInterface` contract, which does not exist in 0.8.
 - **BREAKING — `TreeRenderer` API.** The array entry point `TreeRenderer::render(array $logData, RenderConfig $config)` is renamed to `TreeRenderer::renderTree(array $logData)`, and `RenderConfig` now moves to the constructor (`new TreeRenderer($config)`). `TreeRenderer::render()` now implements `LogRendererInterface::render(LogJson $log)`. The CLI (`stree`, `vendor/bin/stree`) and the `Koriym\SemanticLogger\Stree` namespace are unchanged.
   - Migrate: `(new TreeRenderer())->render($logData, $config)` → `(new TreeRenderer($config))->renderTree($logData)`, or render a log directly with `$log->render(new TreeRenderer($config))`.
 - The tree renderer now lives as a self-contained monorepo subpackage under `src-stree/` (`koriym/stree`), merged into the root autoload and `git subtree split`-able later. The namespace stays `Koriym\SemanticLogger\Stree`, so usage is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING — PHP 8.2 is now the minimum supported version.** CI covers PHP 8.2 through 8.5.
 - `flush()` now resets state in both modes whether it returns or throws. `toArray()` and `jsonSerialize()` are explicitly non-destructive snapshots.
 - `NullSemanticLogger::open()` now returns unique `noop_N` ids per session instead of an empty sentinel; `flush()` resets its counter.
-- `koriym/stree` accepts both `koriym/semantic-logger ^0.8` and `^1.0` during the package transition.
+- `koriym/stree` now requires `koriym/semantic-logger ^1.0` because its renderer implements the 1.0 `LogRendererInterface` contract.
 - **BREAKING — `TreeRenderer` API.** The array entry point `TreeRenderer::render(array $logData, RenderConfig $config)` is renamed to `TreeRenderer::renderTree(array $logData)`, and `RenderConfig` now moves to the constructor (`new TreeRenderer($config)`). `TreeRenderer::render()` now implements `LogRendererInterface::render(LogJson $log)`. The CLI (`stree`, `vendor/bin/stree`) and the `Koriym\SemanticLogger\Stree` namespace are unchanged.
   - Migrate: `(new TreeRenderer())->render($logData, $config)` → `(new TreeRenderer($config))->renderTree($logData)`, or render a log directly with `$log->render(new TreeRenderer($config))`.
 - The tree renderer now lives as a self-contained monorepo subpackage under `src-stree/` (`koriym/stree`), merged into the root autoload and `git subtree split`-able later. The namespace stays `Koriym\SemanticLogger\Stree`, so usage is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Strict and total logger modes.** `SemanticLoggerMode::Strict` remains the constructor default; `SemanticLoggerMode::Total` records core-owned placeholders and diagnostic events instead of allowing logging failures to interrupt the caller.
+- **`mode` in the log envelope.** `SemanticLogger` records `"mode": "strict"|"total"` in the produced document so it is self-describing about its evidential value: in a total-mode document the absence of diagnostics is proof of a clean session, while a document without `mode` carries no such proof. Optional in the schema for 0.9.x; planned to become required in 1.0. `NullSemanticLogger` output intentionally omits it.
 - Bundled schemas for `semantic_logger_error` diagnostics and `semantic_logger_invalid_context` placeholders.
 - Event-only sessions with the required `"open": []` envelope shape across the logger, validator, dynamic schema generator, and `stree`.
 - **`LogRendererInterface`** and **`LogJson::render(LogRendererInterface)`** — a log can render itself with any renderer via double dispatch, without knowing the output format. Implement the interface to add new formats (e.g. Markdown, Mermaid) without touching the logger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - Unreleased
 
 ### Added
+- **Strict and total logger modes.** `SemanticLoggerMode::Strict` remains the constructor default; `SemanticLoggerMode::Total` records core-owned placeholders and diagnostic events instead of allowing logging failures to interrupt the caller.
+- Bundled schemas for `semantic_logger_error` diagnostics and `semantic_logger_invalid_context` placeholders.
+- Event-only sessions with the required `"open": []` envelope shape across the logger, validator, dynamic schema generator, and `stree`.
 - **`LogRendererInterface`** and **`LogJson::render(LogRendererInterface)`** — a log can render itself with any renderer via double dispatch, without knowing the output format. Implement the interface to add new formats (e.g. Markdown, Mermaid) without touching the logger.
 
 ### Changed
+- **BREAKING — context metadata is validated at write time.** Consumer `TYPE` values must match `^[a-z_]+$`; the `semantic_logger_*` namespace is reserved; `SCHEMA_URL` must be an absolute URI or `./schemas/<name>.json`.
+- Context values are frozen as inert JSON trees at write time, preventing nested `JsonSerializable` values from running again during snapshots or flushes. In strict mode, serialization failures therefore surface at the write call instead of during a later flush. In PHP snapshots, nested JSON objects are now represented as `stdClass` instead of associative arrays; the wire JSON shape is unchanged.
+- **BREAKING — PHP 8.2 is now the minimum supported version.** CI covers PHP 8.2 through 8.5.
+- `flush()` now resets state in both modes whether it returns or throws. `toArray()` and `jsonSerialize()` are explicitly non-destructive snapshots.
+- `NullSemanticLogger::open()` now returns unique `noop_N` ids per session instead of an empty sentinel; `flush()` resets its counter.
+- `koriym/stree` accepts both `koriym/semantic-logger ^0.8` and `^1.0` during the package transition.
 - **BREAKING — `TreeRenderer` API.** The array entry point `TreeRenderer::render(array $logData, RenderConfig $config)` is renamed to `TreeRenderer::renderTree(array $logData)`, and `RenderConfig` now moves to the constructor (`new TreeRenderer($config)`). `TreeRenderer::render()` now implements `LogRendererInterface::render(LogJson $log)`. The CLI (`stree`, `vendor/bin/stree`) and the `Koriym\SemanticLogger\Stree` namespace are unchanged.
   - Migrate: `(new TreeRenderer())->render($logData, $config)` → `(new TreeRenderer($config))->renderTree($logData)`, or render a log directly with `$log->render(new TreeRenderer($config))`.
 - The tree renderer now lives as a self-contained monorepo subpackage under `src-stree/` (`koriym/stree`), merged into the root autoload and `git subtree split`-able later. The namespace stays `Koriym\SemanticLogger\Stree`, so usage is unchanged.
+
+### Fixed
+- Strict-mode metadata and serialization failures no longer advance id counters or pop open operations before the write succeeds.
+- Event-only sessions are no longer mistaken for empty sessions and discarded.
+- Incomplete strict snapshots no longer emit self-invalid `"open": []` documents.
+- `DevSemanticLogger` keeps its profiler stack aligned when an inner close fails or a total-mode close is rejected for LIFO mismatch.
+
+### Removed
+- Dead MCP Psalm type aliases left after the MCP implementation moved out of this package.
+
+## [0.8.0] - 2026-04-24
+
+### Changed
+- **BREAKING — tree-only public log envelope.** Matched closes and scoped events serialize under their corresponding open node; top-level `events` and `close` remain only for detached diagnostics.
+- Normalized PHP domain types and tightened static-analysis and coding-standard coverage.
+
+### Fixed
+- Preserved detached events, orphan closes, and duplicate close diagnostics while parsing and rendering semantic trees.
+- Aligned the public JSON Schema and validator with the tree-only envelope, including nested context validation and empty object maps.
+- Resolved schema URL mapping regressions and shipped `docs/schemas` in the Composer distribution so root validation never depends on a remote schema.
 
 ## [0.7.0] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,59 @@ echo json_encode($log, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
 ### Open / Close Ordering
 
-`open` and `close` must be paired in LIFO order. Violations raise exceptions from `Koriym\SemanticLogger\Exception`:
+`open` and `close` must be paired in LIFO order. In the default strict mode, violations raise exceptions from `Koriym\SemanticLogger\Exception`:
 
 - `InvalidOperationOrderException` — `close()` called with an id other than the innermost open
 - `NoOpenOperationsException` — `close()` called with no open operation on the stack
 - `UnclosedLogicException` — `flush()` called while opens are still pending
 
 Wrap work in `try/finally` so `close()` always runs, even on error paths.
+
+## Strict and Total Modes
+
+`SemanticLogger` is strict by default. Strict mode is intended for development and tests: invalid metadata, serialization failures, ordering mistakes, and incomplete sessions are surfaced immediately.
+
+```php
+use Koriym\SemanticLogger\SemanticLogger;
+use Koriym\SemanticLogger\SemanticLoggerMode;
+
+$strictLogger = new SemanticLogger();
+$totalLogger = new SemanticLogger(SemanticLoggerMode::Total);
+```
+
+Total mode is intended for boundaries where logging must remain total. Instead of letting a caller error interrupt the application, it records a core-owned placeholder at the attempted entry's tree position and emits a `semantic_logger_error` diagnostic event. Core diagnostic payloads use bundled schemas and contain only inert JSON values, so reporting a serialization failure cannot recurse into user serialization.
+
+Context values are frozen as an inert JSON tree at each write. Nested `JsonSerializable` values therefore run once, during that write, and are never invoked again by a snapshot or flush. In PHP snapshots, nested JSON objects are represented as `stdClass` rather than associative arrays; the serialized JSON shape is unchanged. Consumers that inspect `toArray()` directly should treat nested context values as JSON-shaped data.
+
+| Condition | Strict | Total |
+|-----------|--------|-------|
+| Invalid `TYPE` or `SCHEMA_URL` | `InvalidContextTypeException` or `InvalidSchemaUrlException`; no mutation | Inline `semantic_logger_invalid_context` placeholder plus diagnostic |
+| Context serialization failure | Original exception; no mutation | Inline placeholder plus exception diagnostic |
+| `close()` without an open or with the wrong LIFO id | Ordering exception; no mutation | Diagnostic; open stack remains unchanged |
+| Valid close whose context cannot serialize | Original exception; open remains retryable | Placeholder close is committed and the span is closed |
+| Sessionless `flush()` | `NoLogSessionException` | Valid empty log with `"open": []` |
+| `flush()` with unclosed spans | `UnclosedLogicException` | Incomplete opens plus `unclosed_at_flush` diagnostic |
+
+Consumer context metadata must follow these rules:
+
+- `TYPE` is non-empty and matches `^[a-z_]+$`.
+- `semantic_logger_*` is reserved for core placeholders and diagnostics.
+- `SCHEMA_URL` is an absolute URI or a relative `./schemas/<name>.json` path.
+
+## Session Lifecycle
+
+A session is the interval between calls to `flush()` and begins implicitly with the first `open()`, `event()`, or diagnostic. Event-only sessions are valid and serialize with the required empty shape `"open": []`.
+
+Both modes reset all session state whenever `flush()` returns or throws. Writes after that call begin a fresh session and operation ids restart from one. This makes one logger instance per worker safe when every request or message boundary flushes in `finally`.
+
+All writers participating in one boundary must share the same logger instance, and exactly one owner must flush it. Multiple owners flushing the same instance split one logical session silently.
+
+`toArray()` and `jsonSerialize()` are non-destructive snapshots:
+
+- Strict mode throws on a sessionless or incomplete session and preserves state. Mid-session dumps are therefore intentionally unavailable in strict mode.
+- Total mode returns an empty sessionless snapshot or an honest incomplete tree. Its `unclosed_at_flush` diagnostic is synthesized for that snapshot only, so repeated snapshots do not accumulate events.
+
+`NullSemanticLogger` follows the same id protocol: `open()` returns unique per-session ids (`noop_1`, `noop_2`, …), `close()` accepts them unconditionally, and `flush()` resets the counter.
 
 ### Try It
 
@@ -217,7 +263,7 @@ Segments are attributed only to the operation they ran inside — the parent's p
 vendor/bin/validate-semantic-log.php path/to/semantic-log.json [path/to/schemas]
 ```
 
-The envelope (root tree) is always validated against the bundled `docs/schemas/semantic-log.json` shipped in the composer dist. You supply a schema directory for your own context schemas — the CLI defaults to `./schemas/` when the second argument is omitted.
+The envelope (root tree) is always validated against the bundled `docs/schemas/semantic-log.json` shipped in the composer dist. Core placeholder and diagnostic contexts also resolve against their bundled schemas. You supply a schema directory for your own context schemas — the CLI defaults to `./schemas/` when the second argument is omitted.
 
 ```php
 use Koriym\SemanticLogger\SemanticLogValidator;

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Context values are frozen as an inert JSON tree at each write. Nested `JsonSeria
 | Sessionless `flush()` | `NoLogSessionException` | Valid empty log with `"open": []` |
 | `flush()` with unclosed spans | `UnclosedLogicException` | Incomplete opens plus `unclosed_at_flush` diagnostic |
 
+Every document produced by `SemanticLogger` declares the mode that produced it as `"mode": "strict"|"total"` in the envelope. In a total-mode document, the absence of diagnostic entries is proof of a clean session; a document without `mode` carries no such proof. `NullSemanticLogger` omits the field by design — its document proves nothing about how it was produced.
+
 Consumer context metadata must follow these rules:
 
 - `TYPE` is non-empty and matches `^[a-z_]+$`.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "justinrainbow/json-schema": "^6.4"
     },
     "require-dev": {

--- a/docs/schemas/semantic-log.json
+++ b/docs/schemas/semantic-log.json
@@ -38,7 +38,7 @@
             "$ref": "#/definitions/operationId"
           },
           "type": {
-            "$ref": "#/definitions/contextType",
+            "allOf": [{ "$ref": "#/definitions/contextType" }],
             "description": "Application-defined event type (e.g., cache_operation, database_query, external_api)"
           },
           "schemaUrl": {
@@ -106,7 +106,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "$ref": "#/definitions/contextType",
+          "allOf": [{ "$ref": "#/definitions/contextType" }],
           "description": "Application-defined context type (e.g., http_request, database_query, business_logic)"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
@@ -139,7 +139,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "$ref": "#/definitions/contextType",
+          "allOf": [{ "$ref": "#/definitions/contextType" }],
           "description": "Application-defined event type"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
@@ -159,7 +159,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "$ref": "#/definitions/contextType",
+          "allOf": [{ "$ref": "#/definitions/contextType" }],
           "description": "Application-defined context type (e.g., http_response, database_result, business_complete)"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },

--- a/docs/schemas/semantic-log.json
+++ b/docs/schemas/semantic-log.json
@@ -17,6 +17,11 @@
     "$schema": {
       "$ref": "#/definitions/schemaUrl"
     },
+    "mode": {
+      "type": "string",
+      "enum": ["strict", "total"],
+      "description": "The logger mode that produced this document. Recorded so the document is self-describing about its own evidential value: in a total-mode document the absence of diagnostic entries is proof of a clean session, while a document without mode carries no such proof. Optional in 0.9.x; planned to become required in 1.0."
+    },
     "open": {
       "type": "array",
       "description": "Top-level root operations in chronological order. Each entry may carry nested child opens, nested events, and its matching close.",

--- a/docs/schemas/semantic-log.json
+++ b/docs/schemas/semantic-log.json
@@ -19,7 +19,6 @@
     },
     "open": {
       "type": "array",
-      "minItems": 1,
       "description": "Top-level root operations in chronological order. Each entry may carry nested child opens, nested events, and its matching close.",
       "items": { "$ref": "#/definitions/openEntry" }
     },
@@ -39,7 +38,7 @@
             "$ref": "#/definitions/operationId"
           },
           "type": {
-            "type": "string", 
+            "$ref": "#/definitions/contextType",
             "description": "Application-defined event type (e.g., cache_operation, database_query, external_api)"
           },
           "schemaUrl": {
@@ -107,7 +106,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "type": "string",
+          "$ref": "#/definitions/contextType",
           "description": "Application-defined context type (e.g., http_request, database_query, business_logic)"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
@@ -140,7 +139,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "type": "string",
+          "$ref": "#/definitions/contextType",
           "description": "Application-defined event type"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
@@ -160,7 +159,7 @@
       "properties": {
         "id": { "$ref": "#/definitions/operationId" },
         "type": {
-          "type": "string",
+          "$ref": "#/definitions/contextType",
           "description": "Application-defined context type (e.g., http_response, database_result, business_complete)"
         },
         "schemaUrl": { "$ref": "#/definitions/schemaUrl" },
@@ -190,7 +189,8 @@
     },
     "contextType": {
       "type": "string",
-      "description": "Application-defined context type identifier. Applications define their own context types through individual schema files"
+      "pattern": "^[a-z_]+$",
+      "description": "Context type identifier. The semantic_logger_* namespace is reserved for core diagnostics and placeholders; applications define other types through individual schema files."
     },
     "operationProfile": {
       "type": "object",

--- a/docs/schemas/semantic-logger-error.json
+++ b/docs/schemas/semantic-logger-error.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json",
+  "title": "Semantic Logger Diagnostic Context",
+  "description": "Core-owned diagnostic emitted when total mode degrades a logging operation.",
+  "type": "object",
+  "required": ["kind", "message"],
+  "properties": {
+    "kind": {
+      "type": "string",
+      "enum": [
+        "invalid_type",
+        "invalid_schema_url",
+        "context_serialization_failed",
+        "close_without_open",
+        "close_id_mismatch",
+        "unclosed_at_flush"
+      ]
+    },
+    "message": { "type": "string" },
+    "exceptionClass": { "type": "string" },
+    "relatedId": { "type": "string" },
+    "originalType": { "type": "string" },
+    "originalSchemaUrl": { "type": "string" },
+    "discardedContext": {
+      "description": "The rejected context. An empty PHP context is encoded as an empty JSON array; non-empty contexts are objects.",
+      "type": ["object", "array"],
+      "additionalProperties": true
+    },
+    "unclosedIds": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z_]+_[0-9]+$" },
+      "uniqueItems": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/semantic-logger-invalid-context.json
+++ b/docs/schemas/semantic-logger-invalid-context.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json",
+  "title": "Semantic Logger Invalid Context Placeholder",
+  "description": "Core-owned placeholder that preserves tree position when a user context cannot be recorded safely.",
+  "type": "object",
+  "required": ["operation", "errors"],
+  "properties": {
+    "operation": {
+      "type": "string",
+      "enum": ["open", "event", "close"]
+    },
+    "errors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "originalType": { "type": "string" },
+    "originalSchemaUrl": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/semantic-logger-invalid-context.json
+++ b/docs/schemas/semantic-logger-invalid-context.json
@@ -17,7 +17,17 @@
         "type": "object",
         "required": ["kind", "message"],
         "properties": {
-          "kind": { "type": "string" },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "invalid_type",
+              "invalid_schema_url",
+              "context_serialization_failed",
+              "close_without_open",
+              "close_id_mismatch",
+              "unclosed_at_flush"
+            ]
+          },
           "message": { "type": "string" }
         },
         "additionalProperties": false

--- a/src-stree/composer.json
+++ b/src-stree/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "koriym/semantic-logger": "^0.8 || ^1.0"
+        "koriym/semantic-logger": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/src-stree/composer.json
+++ b/src-stree/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "koriym/semantic-logger": "^0.8"
+        "php": "^8.2",
+        "koriym/semantic-logger": "^0.8 || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/src-stree/composer.json
+++ b/src-stree/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "koriym/semantic-logger": "^1.0"
+        "koriym/semantic-logger": "^0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/src-stree/src/LogDataParser.php
+++ b/src-stree/src/LogDataParser.php
@@ -31,10 +31,6 @@ final class LogDataParser
 
         /** @var list<array<string, mixed>> $openList */
         $openList = $logData['open'];
-        if ($openList === []) {
-            throw new RuntimeException('Invalid log data: open section is empty');
-        }
-
         $rootNode = count($openList) === 1
             ? $this->parseOpenEntry($openList[0])
             : $this->createForestRoot($openList);

--- a/src-stree/tests/LogDataParserTest.php
+++ b/src-stree/tests/LogDataParserTest.php
@@ -203,6 +203,27 @@ final class LogDataParserTest extends TestCase
         $this->assertSame('b', $tree->children[1]->type);
     }
 
+    public function testEventOnlyLogUsesSyntheticForestRoot(): void
+    {
+        $parser = new LogDataParser();
+        $tree = $parser->parseLogData([
+            'open' => [],
+            'events' => [
+                [
+                    'id' => 'notice_1',
+                    'type' => 'notice',
+                    'schemaUrl' => 'notice.json',
+                    'context' => ['message' => 'event only'],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($tree->isSynthetic);
+        $this->assertCount(1, $tree->children);
+        $this->assertTrue($tree->children[0]->isEvent);
+        $this->assertSame('notice', $tree->children[0]->type);
+    }
+
     public function testParseEventsData(): void
     {
         $logData = [

--- a/src-stree/tests/TreeRendererTest.php
+++ b/src-stree/tests/TreeRendererTest.php
@@ -113,6 +113,24 @@ final class TreeRendererTest extends TestCase
         $this->assertFalse(str_starts_with($lines[1], '└'));
     }
 
+    public function testEventOnlyLogRendersTopLevelEvent(): void
+    {
+        $renderer = new TreeRenderer(new RenderConfig(false, 0.0, 5));
+        $result = $renderer->renderTree([
+            'open' => [],
+            'events' => [
+                [
+                    'id' => 'notice_1',
+                    'type' => 'notice',
+                    'schemaUrl' => 'notice.json',
+                    'context' => ['message' => 'event only'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('notice message=event only [event]', trim($result));
+    }
+
     public function testOrphanCloseRendersAsTopLevelDiagnosticInSingleRootLog(): void
     {
         $logData = [

--- a/src/ContextPreparer.php
+++ b/src/ContextPreparer.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use JsonSerializable;
+use Koriym\SemanticLogger\Exception\InvalidContextTypeException;
+use Koriym\SemanticLogger\Exception\InvalidSchemaUrlException;
+use stdClass;
+use Throwable;
+
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_values;
+use function get_debug_type;
+use function get_object_vars;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function parse_url;
+use function preg_match;
+use function str_starts_with;
+use function strval;
+
+use const JSON_THROW_ON_ERROR;
+use const PHP_URL_SCHEME;
+
+/**
+ * @psalm-import-type ContextData from Types
+ * @psalm-import-type DiagnosticData from Types
+ * @psalm-import-type PreparedContext from Types
+ * @psalm-import-type PreparedMetadata from Types
+ * @psalm-import-type PreparedSerialization from Types
+ */
+final class ContextPreparer
+{
+    private const RESERVED_TYPE_PREFIX = 'semantic_logger_';
+    private const TYPE_PATTERN = '/^[a-z_]+$/D';
+    private const RELATIVE_SCHEMA_PATTERN = '/^\.\/schemas\/[a-zA-Z0-9_-]+\.json$/D';
+    private const URI_SCHEME_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*$/D';
+
+    public function __construct(
+        private readonly SemanticLoggerMode $mode,
+    ) {
+    }
+
+    /** @return PreparedContext */
+    public function prepare(AbstractContext $context, string $operation): array
+    {
+        $metadata = $this->prepareMetadata($context::TYPE, $context::SCHEMA_URL);
+        $serialization = $this->prepareSerialization($context);
+        $diagnostics = array_merge($metadata['diagnostics'], $serialization['diagnostics']);
+
+        if ($diagnostics === [] && $metadata['type'] !== null && $metadata['schemaUrl'] !== null && $serialization['context'] !== null) {
+            return [
+                'type' => $metadata['type'],
+                'schemaUrl' => $metadata['schemaUrl'],
+                'context' => $serialization['context'],
+                'diagnostics' => [],
+            ];
+        }
+
+        if ($serialization['context'] !== null) {
+            $diagnostics = array_map(static function (array $diagnostic) use ($serialization): array {
+                $diagnostic['discardedContext'] = $serialization['context'];
+
+                return $diagnostic;
+            }, $diagnostics);
+        }
+
+        return [
+            'type' => CoreSchema::INVALID_CONTEXT_TYPE,
+            'schemaUrl' => CoreSchema::INVALID_CONTEXT_URL,
+            'context' => $this->placeholderContext($operation, $diagnostics),
+            'diagnostics' => $diagnostics,
+        ];
+    }
+
+    /** @return ContextData */
+    public function freezeContext(AbstractContext $context): array
+    {
+        if ($context instanceof JsonSerializable) {
+            /** @var mixed $serialized */
+            $serialized = $context->jsonSerialize();
+            if (is_array($serialized) && $this->hasOnlyStringKeys($serialized)) {
+                return $this->freezeArray($serialized);
+            }
+
+            // Non-empty list results are not valid object contexts. Preserve
+            // the legacy public-property fallback instead of storing the list.
+        }
+
+        /** @var ContextData $mixedArray */
+        $mixedArray = (array) $context;
+
+        return $this->freezeArray($mixedArray);
+    }
+
+    /** @return PreparedMetadata */
+    private function prepareMetadata(mixed $rawType, mixed $rawSchemaUrl): array
+    {
+        $typeResult = $this->prepareType($rawType);
+        $schemaResult = $this->prepareSchemaUrl($rawSchemaUrl);
+        $diagnostics = [];
+        if ($typeResult['diagnostic'] !== null) {
+            $diagnostics[] = $typeResult['diagnostic'];
+        }
+
+        if ($schemaResult['diagnostic'] !== null) {
+            $diagnostics[] = $schemaResult['diagnostic'];
+        }
+
+        return [
+            'type' => $typeResult['value'],
+            'schemaUrl' => $schemaResult['value'],
+            'diagnostics' => $diagnostics,
+        ];
+    }
+
+    /** @return array{value: string|null, diagnostic: DiagnosticData|null} */
+    private function prepareType(mixed $rawType): array
+    {
+        if (is_string($rawType) && $this->isValidType($rawType)) {
+            return ['value' => $rawType, 'diagnostic' => null];
+        }
+
+        if ($this->mode === SemanticLoggerMode::Strict) {
+            throw new InvalidContextTypeException();
+        }
+
+        return [
+            'value' => null,
+            'diagnostic' => [
+                'kind' => 'invalid_type',
+                'message' => 'Context TYPE must match ^[a-z_]+$ and must not use the semantic_logger_* namespace.',
+                'originalType' => $this->originalValue($rawType),
+            ],
+        ];
+    }
+
+    /** @return array{value: string|null, diagnostic: DiagnosticData|null} */
+    private function prepareSchemaUrl(mixed $rawSchemaUrl): array
+    {
+        if (is_string($rawSchemaUrl) && $this->isValidSchemaUrl($rawSchemaUrl)) {
+            return ['value' => $rawSchemaUrl, 'diagnostic' => null];
+        }
+
+        if ($this->mode === SemanticLoggerMode::Strict) {
+            throw new InvalidSchemaUrlException();
+        }
+
+        return [
+            'value' => null,
+            'diagnostic' => [
+                'kind' => 'invalid_schema_url',
+                'message' => 'Context SCHEMA_URL must be an absolute URI or ./schemas/<name>.json.',
+                'originalSchemaUrl' => $this->originalValue($rawSchemaUrl),
+            ],
+        ];
+    }
+
+    /** @return PreparedSerialization */
+    private function prepareSerialization(AbstractContext $context): array
+    {
+        try {
+            return ['context' => $this->freezeContext($context), 'diagnostics' => []];
+        } catch (Throwable $throwable) {
+            if ($this->mode === SemanticLoggerMode::Strict) {
+                throw $throwable;
+            }
+
+            return [
+                'context' => null,
+                'diagnostics' => [
+                    [
+                        'kind' => 'context_serialization_failed',
+                        'message' => 'Context serialization failed.',
+                        'exceptionClass' => $throwable::class,
+                    ],
+                ],
+            ];
+        }
+    }
+
+    /** @param array<mixed> $context */
+    private function hasOnlyStringKeys(array $context): bool
+    {
+        foreach (array_keys($context) as $key) {
+            if (! is_string($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Freeze user values as an inert JSON tree so later snapshots and flushes
+     * never invoke nested JsonSerializable objects a second time.
+     *
+     * @param array<mixed> $context
+     *
+     * @return ContextData
+     */
+    private function freezeArray(array $context): array
+    {
+        $json = json_encode($context, JSON_THROW_ON_ERROR);
+
+        return $this->contextFromDecoded(json_decode($json, false, 512, JSON_THROW_ON_ERROR));
+    }
+
+    /** @return ContextData */
+    private function contextFromDecoded(mixed $frozen): array
+    {
+        if (is_array($frozen)) {
+            // Only an empty PHP context reaches this JSON-list branch.
+            return [];
+        }
+
+        if (! $frozen instanceof stdClass) {
+            return [];
+        }
+
+        $properties = get_object_vars($frozen);
+        $keys = array_map(
+            static fn (int|string $key): string => strval($key),
+            array_keys($properties),
+        );
+
+        return array_combine($keys, array_values($properties));
+    }
+
+    private function isValidType(string $type): bool
+    {
+        if (preg_match(self::TYPE_PATTERN, $type) !== 1) {
+            return false;
+        }
+
+        return ! str_starts_with($type, self::RESERVED_TYPE_PREFIX);
+    }
+
+    private function isValidSchemaUrl(string $schemaUrl): bool
+    {
+        if ($schemaUrl === '') {
+            return false;
+        }
+
+        if (preg_match(self::RELATIVE_SCHEMA_PATTERN, $schemaUrl) === 1) {
+            return true;
+        }
+
+        $scheme = parse_url($schemaUrl, PHP_URL_SCHEME);
+
+        return is_string($scheme) && preg_match(self::URI_SCHEME_PATTERN, $scheme) === 1;
+    }
+
+    /**
+     * @param list<DiagnosticData> $diagnostics
+     *
+     * @return ContextData
+     */
+    private function placeholderContext(string $operation, array $diagnostics): array
+    {
+        $errors = array_map(
+            static fn (array $diagnostic): array => [
+                'kind' => $diagnostic['kind'],
+                'message' => $diagnostic['message'],
+            ],
+            $diagnostics,
+        );
+        $context = [
+            'operation' => $operation,
+            'errors' => $errors,
+        ];
+
+        foreach ($diagnostics as $diagnostic) {
+            if (isset($diagnostic['originalType'])) {
+                $context['originalType'] = $diagnostic['originalType'];
+            }
+
+            if (isset($diagnostic['originalSchemaUrl'])) {
+                $context['originalSchemaUrl'] = $diagnostic['originalSchemaUrl'];
+            }
+        }
+
+        return $context;
+    }
+
+    private function originalValue(mixed $value): string
+    {
+        return is_string($value) ? $value : get_debug_type($value);
+    }
+}

--- a/src/CoreSchema.php
+++ b/src/CoreSchema.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class CoreSchema
+{
+    public const LOG_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
+    public const DIAGNOSTIC_TYPE = 'semantic_logger_error';
+    public const DIAGNOSTIC_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json';
+    public const INVALID_CONTEXT_TYPE = 'semantic_logger_invalid_context';
+    public const INVALID_CONTEXT_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json';
+}

--- a/src/DevSemanticLogger.php
+++ b/src/DevSemanticLogger.php
@@ -9,6 +9,7 @@ use Koriym\SemanticLogger\Profiler\PhpProfile;
 use Koriym\SemanticLogger\Profiler\XdebugTrace;
 use Koriym\SemanticLogger\Profiler\XHProfResult;
 use Override;
+use Throwable;
 
 use function array_pop;
 use function end;
@@ -74,23 +75,39 @@ final class DevSemanticLogger implements SemanticLoggerInterface
     public function close(AbstractContext $context, string $openId): void
     {
         $tracked = isset($this->startedPhp[$openId]);
+        $currentId = end($this->openStack);
+        $isCurrent = $tracked && $currentId === $openId;
 
-        if ($tracked) {
-            // Stop the being's final segment and capture wallTime BEFORE
-            // inner->close runs, so none of the logger plumbing (inner->close,
-            // xdebug_stop_trace teardown, json writes, etc.) pollutes this
-            // being's profile.
-            $this->stopAndAttachTo($openId);
-            $this->wallTimes[$openId] = $this->startedPhp[$openId]->stop()->wallTime;
-            unset($this->startedPhp[$openId]);
-            array_pop($this->openStack);
-            $this->depth--;
+        if (! $isCurrent) {
+            $this->inner->close($context, $openId);
+
+            return;
         }
 
-        $this->inner->close($context, $openId);
+        // Stop the being's final segment and capture wallTime BEFORE
+        // inner->close runs, so none of the logger plumbing (inner->close,
+        // xdebug_stop_trace teardown, json writes, etc.) pollutes this
+        // being's profile.
+        $this->stopAndAttachTo($openId);
+        $wallTime = $this->startedPhp[$openId]->stop()->wallTime;
+
+        try {
+            $this->inner->close($context, $openId);
+        } catch (Throwable $throwable) {
+            $this->wallTimes[$openId] = ($this->wallTimes[$openId] ?? 0.0) + $wallTime;
+            $this->startedPhp[$openId] = PhpProfile::start();
+            $this->startNewSegment();
+
+            throw $throwable;
+        }
+
+        $this->wallTimes[$openId] = ($this->wallTimes[$openId] ?? 0.0) + $wallTime;
+        unset($this->startedPhp[$openId]);
+        array_pop($this->openStack);
+        $this->depth--;
 
         // Returning to a parent operation: resume profiling under the parent.
-        if ($tracked && $this->depth > 0) {
+        if ($this->depth > 0) {
             $this->startNewSegment();
         }
     }

--- a/src/DevSemanticLogger.php
+++ b/src/DevSemanticLogger.php
@@ -148,6 +148,7 @@ final class DevSemanticLogger implements SemanticLoggerInterface
                 $closeWithProfile,
                 $logJson->events,
                 $logJson->links,
+                $logJson->mode,
             );
         } finally {
             // Best-effort cleanup: stop anything still running so it does not

--- a/src/DynamicSchemaGenerator.php
+++ b/src/DynamicSchemaGenerator.php
@@ -45,7 +45,6 @@ final class DynamicSchemaGenerator
                 '$schema' => ['$ref' => '#/definitions/schemaUrl'],
                 'open' => [
                     'type' => 'array',
-                    'minItems' => 1,
                     'items' => ['$ref' => '#/definitions/openEntry'],
                 ],
                 'close' => [
@@ -83,6 +82,11 @@ final class DynamicSchemaGenerator
                     'type' => 'string',
                     'pattern' => '^[a-z_]+_[0-9]+$',
                     'description' => 'References a parent operation ID',
+                ],
+                'contextType' => [
+                    'type' => 'string',
+                    'pattern' => '^[a-z_]+$',
+                    'description' => 'Context type identifier; semantic_logger_* is reserved for core entries',
                 ],
                 'openEntry' => $this->generateOpenEntrySchema($contextTypes),
                 'closeEntry' => $this->generateCloseEntrySchema($contextTypes),
@@ -133,7 +137,7 @@ final class DynamicSchemaGenerator
             'required' => ['id', 'type', 'schemaUrl', 'context'],
             'properties' => [
                 'id' => ['$ref' => '#/definitions/operationId'],
-                'type' => ['type' => 'string'],
+                'type' => ['$ref' => '#/definitions/contextType'],
                 'schemaUrl' => ['$ref' => '#/definitions/schemaUrl'],
                 'context' => ['type' => 'object', 'additionalProperties' => true],
                 'events' => [
@@ -170,7 +174,7 @@ final class DynamicSchemaGenerator
             'required' => ['id', 'type', 'schemaUrl', 'context'],
             'properties' => [
                 'id' => ['$ref' => '#/definitions/operationId'],
-                'type' => ['type' => 'string'],
+                'type' => ['$ref' => '#/definitions/contextType'],
                 'schemaUrl' => ['$ref' => '#/definitions/schemaUrl'],
                 'openId' => ['$ref' => '#/definitions/openIdReference'],
                 'context' => ['type' => 'object', 'additionalProperties' => true],
@@ -200,7 +204,7 @@ final class DynamicSchemaGenerator
             'required' => ['id', 'type', 'schemaUrl', 'context'],
             'properties' => [
                 'id' => ['$ref' => '#/definitions/operationId'],
-                'type' => ['type' => 'string'],
+                'type' => ['$ref' => '#/definitions/contextType'],
                 'schemaUrl' => ['$ref' => '#/definitions/schemaUrl'],
                 'openId' => ['$ref' => '#/definitions/openIdReference'],
                 'context' => ['type' => 'object', 'additionalProperties' => true],

--- a/src/Exception/InvalidContextMetadataException.php
+++ b/src/Exception/InvalidContextMetadataException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Exception;
+
+abstract class InvalidContextMetadataException extends LogicException
+{
+}

--- a/src/Exception/InvalidContextTypeException.php
+++ b/src/Exception/InvalidContextTypeException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Exception;
+
+final class InvalidContextTypeException extends InvalidContextMetadataException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid semantic context TYPE: expected a non-empty lowercase type matching ^[a-z_]+$ outside the reserved semantic_logger_* namespace.');
+    }
+}

--- a/src/Exception/InvalidSchemaUrlException.php
+++ b/src/Exception/InvalidSchemaUrlException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger\Exception;
+
+final class InvalidSchemaUrlException extends InvalidContextMetadataException
+{
+    public function __construct()
+    {
+        parent::__construct('Invalid semantic context SCHEMA_URL: expected an absolute URI or ./schemas/<name>.json.');
+    }
+}

--- a/src/Exception/UnclosedLogicException.php
+++ b/src/Exception/UnclosedLogicException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Koriym\SemanticLogger\Exception;
 
-use LogicException;
-
 use function sprintf;
 
 final class UnclosedLogicException extends LogicException
@@ -17,7 +15,7 @@ final class UnclosedLogicException extends LogicException
     ) {
         parent::__construct(
             sprintf(
-                'Unclosed operations detected. %d operations remain open. Last operation: %s. See: https://github.com/koriym/semantic-logger/blob/main/docs/unclosed-operations.md',
+                'Unclosed operations detected. %d operations remain open. Last operation: %s. See: https://github.com/koriym/Koriym.SemanticLogger/blob/1.x/README.md#open--close-ordering',
                 $openStackDepth,
                 $lastOperationType,
             ),

--- a/src/LogJson.php
+++ b/src/LogJson.php
@@ -24,10 +24,13 @@ use function array_map;
 final class LogJson implements JsonSerializable
 {
     /**
-     * @param OpenCloseEntryList $open   Top-level opens (one or more) in chronological order.
-     * @param EventEntryList     $close  Internal close entries; matched closes are nested during public serialization.
-     * @param EventEntryList     $events
-     * @param SchemaLinks        $links
+     * @param OpenCloseEntryList      $open   Top-level opens (one or more) in chronological order.
+     * @param EventEntryList          $close  Internal close entries; matched closes are nested during public serialization.
+     * @param EventEntryList          $events
+     * @param SchemaLinks             $links
+     * @param SemanticLoggerMode|null $mode   The logger mode that produced this log. Recorded in the envelope so the
+     *                                        document is self-describing: a total-mode document with no diagnostics
+     *                                        is proof of a clean session, a mode-less document carries no such proof.
      */
     public function __construct(
         public readonly string $schemaUrl,
@@ -35,6 +38,7 @@ final class LogJson implements JsonSerializable
         public readonly array $close,
         public readonly array $events = [],
         public readonly array $links = [],
+        public readonly SemanticLoggerMode|null $mode = null,
     ) {
     }
 
@@ -67,13 +71,16 @@ final class LogJson implements JsonSerializable
         $this->partitionCloses($this->close, $openIds, $closeByOpenId, $orphanCloses);
         $eventsByOpenId = $this->groupEventsByOpenId($this->events);
 
-        $result = [
-            '$schema' => $this->schemaUrl,
-            'open' => array_map(
-                fn (OpenCloseEntry $entry): array => $this->buildTreeOpenEntry($entry, $closeByOpenId, $eventsByOpenId),
-                $this->open,
-            ),
-        ];
+        $result = ['$schema' => $this->schemaUrl];
+
+        if ($this->mode !== null) {
+            $result['mode'] = $this->mode->value;
+        }
+
+        $result['open'] = array_map(
+            fn (OpenCloseEntry $entry): array => $this->buildTreeOpenEntry($entry, $closeByOpenId, $eventsByOpenId),
+            $this->open,
+        );
 
         $topLevelEvents = $this->topLevelTreeEvents($openIds);
         if ($topLevelEvents !== []) {

--- a/src/LogTreeBuilder.php
+++ b/src/LogTreeBuilder.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use SplStack;
+
+use function array_reverse;
+use function iterator_to_array;
+
+/**
+ * @psalm-import-type EventEntryList from Types
+ * @psalm-import-type LogTree from Types
+ * @psalm-import-type OpenChildrenByParent from Types
+ * @psalm-import-type OpenCloseEntryList from Types
+ */
+final class LogTreeBuilder
+{
+    /**
+     * @param OpenCloseEntryList $completedOperations
+     * @param EventEntryList     $closeLog
+     *
+     * @return LogTree
+     */
+    public function completed(array $completedOperations, array $closeLog): array
+    {
+        return $this->buildTree($completedOperations, $closeLog);
+    }
+
+    /**
+     * @param OpenCloseEntryList       $completedOperations
+     * @param SplStack<OpenCloseEntry> $openStack
+     * @param EventEntryList           $closeLog
+     *
+     * @return LogTree
+     */
+    public function includingLive(array $completedOperations, SplStack $openStack, array $closeLog): array
+    {
+        $operations = $completedOperations;
+        /** @var list<OpenCloseEntry> $liveOperations */
+        $liveOperations = array_reverse(iterator_to_array($openStack, false));
+        foreach ($liveOperations as $operation) {
+            $operations[] = $operation;
+        }
+
+        return $this->buildTree($operations, $closeLog);
+    }
+
+    /**
+     * @param OpenCloseEntryList $operations
+     * @param EventEntryList     $closeLog
+     *
+     * @return LogTree
+     */
+    private function buildTree(array $operations, array $closeLog): array
+    {
+        $childrenByParent = $this->groupByParent($operations);
+        $closeByOpenId = [];
+        foreach ($closeLog as $close) {
+            if ($close->openId !== null) {
+                $closeByOpenId[$close->openId] = $close;
+            }
+        }
+
+        return [
+            'open' => $this->buildOpenChildren(null, $childrenByParent),
+            'close' => $this->buildCloseChildren(null, $childrenByParent, $closeByOpenId),
+        ];
+    }
+
+    /**
+     * @param OpenChildrenByParent $childrenByParent
+     *
+     * @return OpenCloseEntryList
+     */
+    private function buildOpenChildren(string|null $parentId, array $childrenByParent): array
+    {
+        $key = $parentId ?? '';
+        if (! isset($childrenByParent[$key])) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($childrenByParent[$key] as $operation) {
+            $result[] = new OpenCloseEntry(
+                $operation->id,
+                $operation->type,
+                $operation->schemaUrl,
+                $operation->context,
+                $this->buildOpenChildren($operation->id, $childrenByParent),
+                $operation->parentId,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param OpenChildrenByParent      $childrenByParent
+     * @param array<string, EventEntry> $closeByOpenId
+     *
+     * @return EventEntryList
+     */
+    private function buildCloseChildren(string|null $parentId, array $childrenByParent, array $closeByOpenId): array
+    {
+        $key = $parentId ?? '';
+        if (! isset($childrenByParent[$key])) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($childrenByParent[$key] as $operation) {
+            $close = $closeByOpenId[$operation->id] ?? null;
+            $childCloses = $this->buildCloseChildren($operation->id, $childrenByParent, $closeByOpenId);
+            if ($close === null) {
+                foreach ($childCloses as $childClose) {
+                    $result[] = $childClose;
+                }
+
+                continue;
+            }
+
+            $result[] = new EventEntry(
+                $close->id,
+                $close->type,
+                $close->schemaUrl,
+                $close->context,
+                $close->openId,
+                $childCloses,
+                $close->profile,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param OpenCloseEntryList $operations
+     *
+     * @return OpenChildrenByParent
+     */
+    private function groupByParent(array $operations): array
+    {
+        $childrenByParent = [];
+        foreach ($operations as $operation) {
+            $key = $operation->parentId ?? '';
+            $childrenByParent[$key][] = $operation;
+        }
+
+        return $childrenByParent;
+    }
+}

--- a/src/NullSemanticLogger.php
+++ b/src/NullSemanticLogger.php
@@ -9,11 +9,9 @@ use Override;
 /**
  * No-op semantic logger
  *
- * A zero-cost {@see SemanticLoggerInterface} for when logging is turned off:
- * open() returns an empty id (callers treat it as "no close needed"), event()
- * and close() do nothing, and flush() returns an empty log session. Useful as a
- * default so instrumentation code can call the logger unconditionally without a
- * runtime cost when observability is disabled.
+ * A minimal {@see SemanticLoggerInterface} for when logging is turned off.
+ * Calls remain unconditional and the open/close id protocol stays intact, while
+ * event() and close() do not retain log data.
  *
  * @psalm-import-type SchemaLinks from Types
  */
@@ -21,10 +19,14 @@ final class NullSemanticLogger implements SemanticLoggerInterface
 {
     private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
 
+    private int $sequence = 0;
+
     #[Override]
     public function open(AbstractContext $context): string
     {
-        return '';
+        $this->sequence++;
+
+        return 'noop_' . (string) $this->sequence;
     }
 
     #[Override]
@@ -41,6 +43,8 @@ final class NullSemanticLogger implements SemanticLoggerInterface
     #[Override]
     public function flush(array $links = []): LogJson
     {
+        $this->sequence = 0;
+
         return new LogJson(self::SEMANTIC_LOG_SCHEMA_URL, [], [], [], $links);
     }
 }

--- a/src/NullSemanticLogger.php
+++ b/src/NullSemanticLogger.php
@@ -17,8 +17,6 @@ use Override;
  */
 final class NullSemanticLogger implements SemanticLoggerInterface
 {
-    private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
-
     private int $sequence = 0;
 
     #[Override]
@@ -45,6 +43,6 @@ final class NullSemanticLogger implements SemanticLoggerInterface
     {
         $this->sequence = 0;
 
-        return new LogJson(self::SEMANTIC_LOG_SCHEMA_URL, [], [], [], $links);
+        return new LogJson(CoreSchema::LOG_URL, [], [], [], $links);
     }
 }

--- a/src/SemanticLogValidator.php
+++ b/src/SemanticLogValidator.php
@@ -26,9 +26,6 @@ use function str_starts_with;
 
 final class SemanticLogValidator implements SemanticLogValidatorInterface
 {
-    private const DIAGNOSTIC_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json';
-    private const INVALID_CONTEXT_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json';
-
     #[Override]
     public function validate(string $file, string $schemaDir): void
     {
@@ -378,8 +375,8 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
     private function resolveBundledCoreSchema(string $schemaUrl): string|null
     {
         $filename = match ($schemaUrl) {
-            self::DIAGNOSTIC_SCHEMA_URL => 'semantic-logger-error.json',
-            self::INVALID_CONTEXT_SCHEMA_URL => 'semantic-logger-invalid-context.json',
+            CoreSchema::DIAGNOSTIC_URL => 'semantic-logger-error.json',
+            CoreSchema::INVALID_CONTEXT_URL => 'semantic-logger-invalid-context.json',
             default => null,
         };
         if ($filename === null) {

--- a/src/SemanticLogValidator.php
+++ b/src/SemanticLogValidator.php
@@ -26,6 +26,9 @@ use function str_starts_with;
 
 final class SemanticLogValidator implements SemanticLogValidatorInterface
 {
+    private const DIAGNOSTIC_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json';
+    private const INVALID_CONTEXT_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json';
+
     #[Override]
     public function validate(string $file, string $schemaDir): void
     {
@@ -337,9 +340,14 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
      */
     private function resolveSchemaPath(string $schemaUrl, string $schemaDir): string|null
     {
+        $filename = basename($schemaUrl);
+        $bundledCoreSchema = $this->resolveBundledCoreSchema($schemaUrl);
+        if ($bundledCoreSchema !== null) {
+            return $bundledCoreSchema;
+        }
+
         // Handle relative paths like "./schemas/http_request.json"
         if (str_starts_with($schemaUrl, './schemas/')) {
-            $filename = basename($schemaUrl);
             $schemaFile = realpath($schemaDir . '/' . $filename);
 
             return $schemaFile !== false ? $schemaFile : null;
@@ -353,8 +361,6 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
         }
 
         // For absolute URLs, try to extract filename and map to local files
-        $filename = basename($schemaUrl);
-
         // Special case: complex-query.json from external URL
         if ($filename === 'complex-query.json') {
             $localFile = realpath($schemaDir . '/complex_query.json');
@@ -365,6 +371,22 @@ final class SemanticLogValidator implements SemanticLogValidatorInterface
 
         // General case: try exact filename match
         $schemaFile = realpath($schemaDir . '/' . $filename);
+
+        return $schemaFile !== false ? $schemaFile : null;
+    }
+
+    private function resolveBundledCoreSchema(string $schemaUrl): string|null
+    {
+        $filename = match ($schemaUrl) {
+            self::DIAGNOSTIC_SCHEMA_URL => 'semantic-logger-error.json',
+            self::INVALID_CONTEXT_SCHEMA_URL => 'semantic-logger-invalid-context.json',
+            default => null,
+        };
+        if ($filename === null) {
+            return null;
+        }
+
+        $schemaFile = realpath(dirname(__DIR__) . '/docs/schemas/' . $filename);
 
         return $schemaFile !== false ? $schemaFile : null;
     }

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -5,29 +5,60 @@ declare(strict_types=1);
 namespace Koriym\SemanticLogger;
 
 use JsonSerializable;
+use Koriym\SemanticLogger\Exception\InvalidContextTypeException;
 use Koriym\SemanticLogger\Exception\InvalidOperationOrderException;
+use Koriym\SemanticLogger\Exception\InvalidSchemaUrlException;
 use Koriym\SemanticLogger\Exception\NoLogSessionException;
 use Koriym\SemanticLogger\Exception\NoOpenOperationsException;
 use Koriym\SemanticLogger\Exception\UnclosedLogicException;
 use Override;
 use SplStack;
+use stdClass;
+use Throwable;
 
-use function assert;
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function array_reverse;
+use function array_values;
+use function get_debug_type;
+use function get_object_vars;
 use function is_array;
 use function is_string;
+use function iterator_to_array;
+use function json_decode;
+use function json_encode;
+use function parse_url;
+use function preg_match;
+use function str_starts_with;
+use function strval;
+
+use const JSON_THROW_ON_ERROR;
+use const PHP_URL_SCHEME;
 
 /**
  * @psalm-import-type ContextData from Types
+ * @psalm-import-type DiagnosticData from Types
+ * @psalm-import-type DiagnosticKind from Types
  * @psalm-import-type EventEntryList from Types
  * @psalm-import-type LogSessionArray from Types
  * @psalm-import-type OpenChildrenByParent from Types
  * @psalm-import-type OpenCloseEntryList from Types
+ * @psalm-import-type PreparedContext from Types
  * @psalm-import-type SchemaLinks from Types
  * @psalm-import-type TypeCounts from Types
  */
 final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 {
     private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
+    private const DIAGNOSTIC_TYPE = 'semantic_logger_error';
+    private const DIAGNOSTIC_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json';
+    private const INVALID_CONTEXT_TYPE = 'semantic_logger_invalid_context';
+    private const INVALID_CONTEXT_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json';
+    private const RESERVED_TYPE_PREFIX = 'semantic_logger_';
+    private const TYPE_PATTERN = '/^[a-z_]+$/D';
+    private const RELATIVE_SCHEMA_PATTERN = '/^\.\/schemas\/[a-zA-Z0-9_-]+\.json$/D';
+    private const URI_SCHEME_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*$/D';
 
     /** @var EventEntryList */
     private array $events = [];
@@ -44,8 +75,9 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     /** @var TypeCounts */
     private array $typeCounts = [];
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly SemanticLoggerMode $mode = SemanticLoggerMode::Strict,
+    ) {
         /** @var SplStack<OpenCloseEntry> $openStack */
         $openStack = new SplStack();
         $this->openStack = $openStack;
@@ -54,25 +86,18 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     #[Override]
     public function open(AbstractContext $context): string
     {
-        $type = $context::TYPE;
-        assert(is_string($type));
-        $this->typeCounts[$type] = ($this->typeCounts[$type] ?? 0) + 1;
-        $operationId = "{$type}_{$this->typeCounts[$type]}";
-
-        $schemaUrl = $context::SCHEMA_URL;
-        assert(is_string($schemaUrl));
-
+        $prepared = $this->prepareContext($context, 'open');
+        $operationId = $this->nextId($prepared['type']);
         $parentId = $this->openStack->isEmpty() ? null : $this->openStack->top()->id;
-
-        $contextArray = $this->contextToArray($context);
         $this->openStack->push(new OpenCloseEntry(
             $operationId,
-            $type,
-            $schemaUrl,
-            $contextArray,
+            $prepared['type'],
+            $prepared['schemaUrl'],
+            $prepared['context'],
             [],
             $parentId,
         ));
+        $this->recordDiagnostics($this->withRelatedId($prepared['diagnostics'], $operationId), $operationId);
 
         return $operationId;
     }
@@ -80,59 +105,61 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     #[Override]
     public function event(AbstractContext $context): void
     {
-        $type = $context::TYPE;
-        assert(is_string($type));
-        $this->typeCounts[$type] = ($this->typeCounts[$type] ?? 0) + 1;
-        $eventId = "{$type}_{$this->typeCounts[$type]}";
-
-        $schemaUrl = $context::SCHEMA_URL;
-        assert(is_string($schemaUrl));
-
-        $contextArray = $this->contextToArray($context);
-
-        // Get current open operation ID for correlation
+        $prepared = $this->prepareContext($context, 'event');
+        $eventId = $this->nextId($prepared['type']);
         $currentOpenId = $this->openStack->isEmpty() ? null : $this->openStack->top()->id;
-
         $this->events[] = new EventEntry(
             $eventId,
-            $type,
-            $schemaUrl,
-            $contextArray,
+            $prepared['type'],
+            $prepared['schemaUrl'],
+            $prepared['context'],
             $currentOpenId,
         );
+        $this->recordDiagnostics($this->withRelatedId($prepared['diagnostics'], $eventId), $currentOpenId);
     }
 
     #[Override]
     public function close(AbstractContext $context, string $openId): void
     {
         if ($this->openStack->isEmpty()) {
+            if ($this->mode === SemanticLoggerMode::Total) {
+                $this->recordRejectedClose('close_without_open', 'Cannot close operation: no open operations', $context, $openId, null);
+
+                return;
+            }
+
             throw new NoOpenOperationsException();
         }
 
         $lastOpen = $this->openStack->top();
         if ($lastOpen->id !== $openId) {
+            if ($this->mode === SemanticLoggerMode::Total) {
+                $this->recordRejectedClose(
+                    'close_id_mismatch',
+                    "Cannot close operation '{$openId}': expected '{$lastOpen->id}' (LIFO order required)",
+                    $context,
+                    $openId,
+                    $lastOpen->id,
+                );
+
+                return;
+            }
+
             throw new InvalidOperationOrderException($openId, $lastOpen->id);
         }
 
+        $prepared = $this->prepareContext($context, 'close');
+        $closeId = $this->nextId($prepared['type']);
         $completedOpen = $this->openStack->pop();
         $this->completedOperations[] = $completedOpen;
-
-        $type = $context::TYPE;
-        assert(is_string($type));
-        $this->typeCounts[$type] = ($this->typeCounts[$type] ?? 0) + 1;
-        $closeId = "{$type}_{$this->typeCounts[$type]}";
-
-        $schemaUrl = $context::SCHEMA_URL;
-        assert(is_string($schemaUrl));
-
-        $contextArray = $this->contextToArray($context);
         $this->closeLog[] = new EventEntry(
             $closeId,
-            $type,
-            $schemaUrl,
-            $contextArray,
+            $prepared['type'],
+            $prepared['schemaUrl'],
+            $prepared['context'],
             $openId,
         );
+        $this->recordDiagnostics($this->withRelatedId($prepared['diagnostics'], $openId), $openId);
     }
 
     #[Override]
@@ -151,13 +178,52 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     #[Override]
     public function flush(array $links = []): LogJson
     {
-        // Check for any operations at all
-        if (empty($this->completedOperations) && $this->openStack->isEmpty()) {
+        try {
+            if (! $this->hasSession()) {
+                if ($this->mode === SemanticLoggerMode::Total) {
+                    return $this->emptyLog($links);
+                }
+
+                throw new NoLogSessionException('no open entry');
+            }
+
+            if ($this->openStack->isEmpty()) {
+                return $this->buildLogJson($links);
+            }
+
+            if ($this->mode === SemanticLoggerMode::Strict) {
+                $lastOpen = $this->getLastOpenContext();
+
+                throw new UnclosedLogicException(
+                    $this->openStack->count(),
+                    $lastOpen->type,
+                    $lastOpen->schemaUrl,
+                );
+            }
+
+            $this->recordDiagnostics([$this->unclosedDiagnostic()], null);
+
+            return $this->buildLogJson($links, true);
+        } finally {
+            $this->resetState();
+        }
+    }
+
+    private function createLogJson(): LogJson
+    {
+        if (! $this->hasSession()) {
+            if ($this->mode === SemanticLoggerMode::Total) {
+                return $this->emptyLog();
+            }
+
             throw new NoLogSessionException('no open entry');
         }
 
-        // Detect unclosed operations - this is a programming error
-        if (! $this->openStack->isEmpty()) {
+        if ($this->openStack->isEmpty()) {
+            return $this->buildLogJson();
+        }
+
+        if ($this->mode === SemanticLoggerMode::Strict) {
             $lastOpen = $this->getLastOpenContext();
 
             throw new UnclosedLogicException(
@@ -167,38 +233,15 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
             );
         }
 
-        $logJson = new LogJson(
-            self::SEMANTIC_LOG_SCHEMA_URL,
-            $this->buildNestedOpen(),
-            $this->buildNestedClose(),
-            $this->events,
-            $links,
+        $diagnostic = $this->diagnosticEntry(
+            $this->unclosedDiagnostic(),
+            null,
+            $this->previewId(self::DIAGNOSTIC_TYPE),
         );
+        $events = $this->events;
+        $events[] = $diagnostic;
 
-        // Clear internal state
-        /** @var SplStack<OpenCloseEntry> $openStack */
-        $openStack = new SplStack();
-        $this->openStack = $openStack;
-        $this->closeLog = [];
-        $this->completedOperations = [];
-        $this->events = [];
-        $this->typeCounts = [];
-
-        return $logJson;
-    }
-
-    private function createLogJson(): LogJson
-    {
-        if (empty($this->completedOperations) && $this->openStack->isEmpty()) {
-            throw new NoLogSessionException('no open entry');
-        }
-
-        return new LogJson(
-            self::SEMANTIC_LOG_SCHEMA_URL,
-            $this->buildNestedOpen(),
-            $this->buildNestedClose(),
-            $this->events,
-        );
+        return $this->buildLogJson([], true, $events);
     }
 
     private function getLastOpenContext(): OpenCloseEntry
@@ -217,9 +260,9 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
      *
      * @return OpenCloseEntryList
      */
-    private function buildNestedOpen(): array
+    private function buildNestedOpen(bool $includeLive = false): array
     {
-        $childrenByParent = $this->groupByParent();
+        $childrenByParent = $this->groupByParent($this->allOpenOperations($includeLive));
 
         return $this->buildOpenChildren(null, $childrenByParent);
     }
@@ -259,9 +302,9 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
      *
      * @return EventEntryList
      */
-    private function buildNestedClose(): array
+    private function buildNestedClose(bool $includeLive = false): array
     {
-        $childrenByParent = $this->groupByParent();
+        $childrenByParent = $this->groupByParent($this->allOpenOperations($includeLive));
         $closeByOpenId = [];
         foreach ($this->closeLog as $close) {
             if ($close->openId !== null) {
@@ -288,7 +331,12 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         $result = [];
         foreach ($childrenByParent[$key] as $op) {
             $close = $closeByOpenId[$op->id] ?? null;
+            $childCloses = $this->buildCloseChildren($op->id, $childrenByParent, $closeByOpenId);
             if ($close === null) {
+                foreach ($childCloses as $childClose) {
+                    $result[] = $childClose;
+                }
+
                 continue;
             }
 
@@ -298,7 +346,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
                 $close->schemaUrl,
                 $close->context,
                 $close->openId,
-                $this->buildCloseChildren($op->id, $childrenByParent, $closeByOpenId),
+                $childCloses,
                 $close->profile,
             );
         }
@@ -306,11 +354,15 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         return $result;
     }
 
-    /** @return OpenChildrenByParent */
-    private function groupByParent(): array
+    /**
+     * @param OpenCloseEntryList $operations
+     *
+     * @return OpenChildrenByParent
+     */
+    private function groupByParent(array $operations): array
     {
         $childrenByParent = [];
-        foreach ($this->completedOperations as $op) {
+        foreach ($operations as $op) {
             $key = $op->parentId ?? '';
             $childrenByParent[$key][] = $op;
         }
@@ -333,15 +385,343 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         if ($context instanceof JsonSerializable) {
             /** @var mixed $serialized */
             $serialized = $context->jsonSerialize();
-            if (is_array($serialized)) {
-                /** @var ContextData $serialized */
-                return $serialized;
+            if (is_array($serialized) && $this->hasOnlyStringKeys($serialized)) {
+                return $this->freezeContext($serialized);
             }
         }
 
         /** @var ContextData $mixedArray */
         $mixedArray = (array) $context;
 
-        return $mixedArray;
+        return $this->freezeContext($mixedArray);
+    }
+
+    /** @param array<mixed> $context */
+    private function hasOnlyStringKeys(array $context): bool
+    {
+        foreach (array_keys($context) as $key) {
+            if (! is_string($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Freeze user values as an inert JSON tree so later snapshots and flushes
+     * never invoke nested JsonSerializable objects a second time.
+     *
+     * @param array<mixed> $context
+     *
+     * @return ContextData
+     */
+    private function freezeContext(array $context): array
+    {
+        $json = json_encode($context, JSON_THROW_ON_ERROR);
+
+        return $this->contextFromDecoded(json_decode($json, false, 512, JSON_THROW_ON_ERROR));
+    }
+
+    /** @return ContextData */
+    private function contextFromDecoded(mixed $frozen): array
+    {
+        if (is_array($frozen)) {
+            // Only an empty PHP context reaches this JSON-list branch;
+            // non-empty lists are rejected before context freezing.
+            return [];
+        }
+
+        if ($frozen instanceof stdClass) {
+            $properties = get_object_vars($frozen);
+            $keys = array_map(
+                static fn (int|string $key): string => strval($key),
+                array_keys($properties),
+            );
+
+            return array_combine($keys, array_values($properties));
+        }
+
+        return [];
+    }
+
+    /**
+     * @param SchemaLinks    $links
+     * @param EventEntryList $events
+     */
+    private function buildLogJson(array $links = [], bool $includeLive = false, array|null $events = null): LogJson
+    {
+        return new LogJson(
+            self::SEMANTIC_LOG_SCHEMA_URL,
+            $this->buildNestedOpen($includeLive),
+            $this->buildNestedClose($includeLive),
+            $events ?? $this->events,
+            $links,
+        );
+    }
+
+    /** @param SchemaLinks $links */
+    private function emptyLog(array $links = []): LogJson
+    {
+        return new LogJson(self::SEMANTIC_LOG_SCHEMA_URL, [], [], [], $links);
+    }
+
+    private function hasSession(): bool
+    {
+        return $this->completedOperations !== []
+            || ! $this->openStack->isEmpty()
+            || $this->events !== []
+            || $this->closeLog !== [];
+    }
+
+    private function resetState(): void
+    {
+        /** @var SplStack<OpenCloseEntry> $openStack */
+        $openStack = new SplStack();
+        $this->openStack = $openStack;
+        $this->closeLog = [];
+        $this->completedOperations = [];
+        $this->events = [];
+        $this->typeCounts = [];
+    }
+
+    private function nextId(string $type): string
+    {
+        $this->typeCounts[$type] = ($this->typeCounts[$type] ?? 0) + 1;
+
+        return $type . '_' . $this->typeCounts[$type];
+    }
+
+    private function previewId(string $type): string
+    {
+        return $type . '_' . (($this->typeCounts[$type] ?? 0) + 1);
+    }
+
+    /** @return OpenCloseEntryList */
+    private function allOpenOperations(bool $includeLive): array
+    {
+        $operations = $this->completedOperations;
+        if (! $includeLive) {
+            return $operations;
+        }
+
+        /** @var list<OpenCloseEntry> $liveOperations */
+        $liveOperations = array_reverse(iterator_to_array($this->openStack, false));
+        foreach ($liveOperations as $operation) {
+            $operations[] = $operation;
+        }
+
+        return $operations;
+    }
+
+    /** @return PreparedContext */
+    private function prepareContext(AbstractContext $context, string $operation): array
+    {
+        /** @var mixed $rawType */
+        $rawType = $context::TYPE;
+        /** @var mixed $rawSchemaUrl */
+        $rawSchemaUrl = $context::SCHEMA_URL;
+        /** @var list<DiagnosticData> $diagnostics */
+        $diagnostics = [];
+        $type = is_string($rawType) && $this->isValidType($rawType) ? $rawType : null;
+        $schemaUrl = is_string($rawSchemaUrl) && $this->isValidSchemaUrl($rawSchemaUrl) ? $rawSchemaUrl : null;
+
+        if ($type === null) {
+            if ($this->mode === SemanticLoggerMode::Strict) {
+                throw new InvalidContextTypeException();
+            }
+
+            $diagnostics[] = [
+                'kind' => 'invalid_type',
+                'message' => 'Context TYPE must match ^[a-z_]+$ and must not use the semantic_logger_* namespace.',
+                'originalType' => $this->originalValue($rawType),
+            ];
+        }
+
+        if ($schemaUrl === null) {
+            if ($this->mode === SemanticLoggerMode::Strict) {
+                throw new InvalidSchemaUrlException();
+            }
+
+            $diagnostics[] = [
+                'kind' => 'invalid_schema_url',
+                'message' => 'Context SCHEMA_URL must be an absolute URI or ./schemas/<name>.json.',
+                'originalSchemaUrl' => $this->originalValue($rawSchemaUrl),
+            ];
+        }
+
+        $serialized = [];
+        $serializationSucceeded = false;
+        try {
+            $serialized = $this->contextToArray($context);
+            $serializationSucceeded = true;
+        } catch (Throwable $throwable) {
+            if ($this->mode === SemanticLoggerMode::Strict) {
+                throw $throwable;
+            }
+
+            $diagnostics[] = [
+                'kind' => 'context_serialization_failed',
+                'message' => 'Context serialization failed.',
+                'exceptionClass' => $throwable::class,
+            ];
+        }
+
+        if ($diagnostics === [] && $type !== null && $schemaUrl !== null) {
+            return [
+                'type' => $type,
+                'schemaUrl' => $schemaUrl,
+                'context' => $serialized,
+                'diagnostics' => [],
+            ];
+        }
+
+        if ($serializationSucceeded) {
+            $diagnostics = array_map(static function (array $diagnostic) use ($serialized): array {
+                $diagnostic['discardedContext'] = $serialized;
+
+                return $diagnostic;
+            }, $diagnostics);
+        }
+
+        return [
+            'type' => self::INVALID_CONTEXT_TYPE,
+            'schemaUrl' => self::INVALID_CONTEXT_SCHEMA_URL,
+            'context' => $this->placeholderContext($operation, $diagnostics),
+            'diagnostics' => $diagnostics,
+        ];
+    }
+
+    private function isValidType(mixed $type): bool
+    {
+        if (! is_string($type) || preg_match(self::TYPE_PATTERN, $type) !== 1) {
+            return false;
+        }
+
+        return ! str_starts_with($type, self::RESERVED_TYPE_PREFIX);
+    }
+
+    private function isValidSchemaUrl(mixed $schemaUrl): bool
+    {
+        if (! is_string($schemaUrl) || $schemaUrl === '') {
+            return false;
+        }
+
+        if (preg_match(self::RELATIVE_SCHEMA_PATTERN, $schemaUrl) === 1) {
+            return true;
+        }
+
+        $scheme = parse_url($schemaUrl, PHP_URL_SCHEME);
+
+        return is_string($scheme) && preg_match(self::URI_SCHEME_PATTERN, $scheme) === 1;
+    }
+
+    /**
+     * @param list<DiagnosticData> $diagnostics
+     *
+     * @return ContextData
+     */
+    private function placeholderContext(string $operation, array $diagnostics): array
+    {
+        $errors = array_map(
+            static fn (array $diagnostic): array => [
+                'kind' => $diagnostic['kind'],
+                'message' => $diagnostic['message'],
+            ],
+            $diagnostics,
+        );
+        $context = [
+            'operation' => $operation,
+            'errors' => $errors,
+        ];
+
+        foreach ($diagnostics as $diagnostic) {
+            if (isset($diagnostic['originalType'])) {
+                $context['originalType'] = $diagnostic['originalType'];
+            }
+
+            if (isset($diagnostic['originalSchemaUrl'])) {
+                $context['originalSchemaUrl'] = $diagnostic['originalSchemaUrl'];
+            }
+        }
+
+        return $context;
+    }
+
+    private function originalValue(mixed $value): string
+    {
+        return is_string($value) ? $value : get_debug_type($value);
+    }
+
+    /**
+     * @param list<DiagnosticData> $diagnostics
+     *
+     * @return list<DiagnosticData>
+     */
+    private function withRelatedId(array $diagnostics, string $relatedId): array
+    {
+        return array_map(static function (array $diagnostic) use ($relatedId): array {
+            $diagnostic['relatedId'] = $relatedId;
+
+            return $diagnostic;
+        }, $diagnostics);
+    }
+
+    /** @param list<DiagnosticData> $diagnostics */
+    private function recordDiagnostics(array $diagnostics, string|null $openId): void
+    {
+        foreach ($diagnostics as $diagnostic) {
+            $this->events[] = $this->diagnosticEntry($diagnostic, $openId);
+        }
+    }
+
+    /** @param DiagnosticData $diagnostic */
+    private function diagnosticEntry(array $diagnostic, string|null $openId, string|null $id = null): EventEntry
+    {
+        return new EventEntry(
+            $id ?? $this->nextId(self::DIAGNOSTIC_TYPE),
+            self::DIAGNOSTIC_TYPE,
+            self::DIAGNOSTIC_SCHEMA_URL,
+            $diagnostic,
+            $openId,
+        );
+    }
+
+    /** @param DiagnosticKind $kind */
+    private function recordRejectedClose(
+        string $kind,
+        string $message,
+        AbstractContext $context,
+        string $attemptedId,
+        string|null $currentOpenId,
+    ): void {
+        $diagnostic = [
+            'kind' => $kind,
+            'message' => $message,
+            'relatedId' => $attemptedId,
+        ];
+
+        try {
+            $diagnostic['discardedContext'] = $this->contextToArray($context);
+        } catch (Throwable $throwable) {
+            $diagnostic['exceptionClass'] = $throwable::class;
+        }
+
+        $this->recordDiagnostics([$diagnostic], $currentOpenId);
+    }
+
+    /** @return DiagnosticData */
+    private function unclosedDiagnostic(): array
+    {
+        $ids = array_map(
+            static fn (OpenCloseEntry $entry): string => $entry->id,
+            array_reverse(iterator_to_array($this->openStack, false)),
+        );
+
+        return [
+            'kind' => 'unclosed_at_flush',
+            'message' => 'Log session ended with unclosed operations.',
+            'unclosedIds' => $ids,
+        ];
     }
 }

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -259,13 +259,14 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
             $tree['close'],
             $events ?? $this->events,
             $links,
+            $this->mode,
         );
     }
 
     /** @param SchemaLinks $links */
     private function emptyLog(array $links = []): LogJson
     {
-        return new LogJson(CoreSchema::LOG_URL, [], [], [], $links);
+        return new LogJson(CoreSchema::LOG_URL, [], [], [], $links, $this->mode);
     }
 
     private function hasSession(): bool

--- a/src/SemanticLogger.php
+++ b/src/SemanticLogger.php
@@ -5,61 +5,30 @@ declare(strict_types=1);
 namespace Koriym\SemanticLogger;
 
 use JsonSerializable;
-use Koriym\SemanticLogger\Exception\InvalidContextTypeException;
 use Koriym\SemanticLogger\Exception\InvalidOperationOrderException;
-use Koriym\SemanticLogger\Exception\InvalidSchemaUrlException;
 use Koriym\SemanticLogger\Exception\NoLogSessionException;
 use Koriym\SemanticLogger\Exception\NoOpenOperationsException;
 use Koriym\SemanticLogger\Exception\UnclosedLogicException;
 use Override;
 use SplStack;
-use stdClass;
 use Throwable;
 
-use function array_combine;
-use function array_keys;
 use function array_map;
 use function array_reverse;
-use function array_values;
-use function get_debug_type;
-use function get_object_vars;
-use function is_array;
-use function is_string;
 use function iterator_to_array;
-use function json_decode;
-use function json_encode;
-use function parse_url;
-use function preg_match;
-use function str_starts_with;
-use function strval;
-
-use const JSON_THROW_ON_ERROR;
-use const PHP_URL_SCHEME;
 
 /**
- * @psalm-import-type ContextData from Types
  * @psalm-import-type DiagnosticData from Types
  * @psalm-import-type DiagnosticKind from Types
  * @psalm-import-type EventEntryList from Types
+ * @psalm-import-type LogTree from Types
  * @psalm-import-type LogSessionArray from Types
- * @psalm-import-type OpenChildrenByParent from Types
  * @psalm-import-type OpenCloseEntryList from Types
- * @psalm-import-type PreparedContext from Types
  * @psalm-import-type SchemaLinks from Types
  * @psalm-import-type TypeCounts from Types
  */
 final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 {
-    private const SEMANTIC_LOG_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
-    private const DIAGNOSTIC_TYPE = 'semantic_logger_error';
-    private const DIAGNOSTIC_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-error.json';
-    private const INVALID_CONTEXT_TYPE = 'semantic_logger_invalid_context';
-    private const INVALID_CONTEXT_SCHEMA_URL = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-logger-invalid-context.json';
-    private const RESERVED_TYPE_PREFIX = 'semantic_logger_';
-    private const TYPE_PATTERN = '/^[a-z_]+$/D';
-    private const RELATIVE_SCHEMA_PATTERN = '/^\.\/schemas\/[a-zA-Z0-9_-]+\.json$/D';
-    private const URI_SCHEME_PATTERN = '/^[a-zA-Z][a-zA-Z0-9+.-]*$/D';
-
     /** @var EventEntryList */
     private array $events = [];
 
@@ -74,6 +43,8 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 
     /** @var TypeCounts */
     private array $typeCounts = [];
+    private readonly ContextPreparer $contextPreparer;
+    private readonly LogTreeBuilder $logTreeBuilder;
 
     public function __construct(
         private readonly SemanticLoggerMode $mode = SemanticLoggerMode::Strict,
@@ -81,12 +52,14 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         /** @var SplStack<OpenCloseEntry> $openStack */
         $openStack = new SplStack();
         $this->openStack = $openStack;
+        $this->contextPreparer = new ContextPreparer($mode);
+        $this->logTreeBuilder = new LogTreeBuilder();
     }
 
     #[Override]
     public function open(AbstractContext $context): string
     {
-        $prepared = $this->prepareContext($context, 'open');
+        $prepared = $this->contextPreparer->prepare($context, 'open');
         $operationId = $this->nextId($prepared['type']);
         $parentId = $this->openStack->isEmpty() ? null : $this->openStack->top()->id;
         $this->openStack->push(new OpenCloseEntry(
@@ -105,7 +78,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     #[Override]
     public function event(AbstractContext $context): void
     {
-        $prepared = $this->prepareContext($context, 'event');
+        $prepared = $this->contextPreparer->prepare($context, 'event');
         $eventId = $this->nextId($prepared['type']);
         $currentOpenId = $this->openStack->isEmpty() ? null : $this->openStack->top()->id;
         $this->events[] = new EventEntry(
@@ -148,7 +121,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
             throw new InvalidOperationOrderException($openId, $lastOpen->id);
         }
 
-        $prepared = $this->prepareContext($context, 'close');
+        $prepared = $this->contextPreparer->prepare($context, 'close');
         $closeId = $this->nextId($prepared['type']);
         $completedOpen = $this->openStack->pop();
         $this->completedOperations[] = $completedOpen;
@@ -188,7 +161,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
             }
 
             if ($this->openStack->isEmpty()) {
-                return $this->buildLogJson($links);
+                return $this->buildCompletedLog($links);
             }
 
             if ($this->mode === SemanticLoggerMode::Strict) {
@@ -203,7 +176,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
 
             $this->recordDiagnostics([$this->unclosedDiagnostic()], null);
 
-            return $this->buildLogJson($links, true);
+            return $this->buildLiveLog($links);
         } finally {
             $this->resetState();
         }
@@ -220,7 +193,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         }
 
         if ($this->openStack->isEmpty()) {
-            return $this->buildLogJson();
+            return $this->buildCompletedLog();
         }
 
         if ($this->mode === SemanticLoggerMode::Strict) {
@@ -236,12 +209,12 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         $diagnostic = $this->diagnosticEntry(
             $this->unclosedDiagnostic(),
             null,
-            $this->previewId(self::DIAGNOSTIC_TYPE),
+            $this->previewId(CoreSchema::DIAGNOSTIC_TYPE),
         );
         $events = $this->events;
         $events[] = $diagnostic;
 
-        return $this->buildLogJson([], true, $events);
+        return $this->buildLiveLog([], $events);
     }
 
     private function getLastOpenContext(): OpenCloseEntry
@@ -252,209 +225,38 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     }
 
     /**
-     * Build the open tree from real parent-child links captured at open() time.
-     *
-     * Each completed operation carries its own parentId; children are grouped
-     * under their parent and appear in chronological close order (which equals
-     * open order for correctly-nested LIFO sessions).
-     *
-     * @return OpenCloseEntryList
+     * @param SchemaLinks    $links
+     * @param EventEntryList $events
      */
-    private function buildNestedOpen(bool $includeLive = false): array
+    private function buildCompletedLog(array $links = [], array|null $events = null): LogJson
     {
-        $childrenByParent = $this->groupByParent($this->allOpenOperations($includeLive));
+        $tree = $this->logTreeBuilder->completed($this->completedOperations, $this->closeLog);
 
-        return $this->buildOpenChildren(null, $childrenByParent);
-    }
-
-    /**
-     * @param OpenChildrenByParent $childrenByParent
-     *
-     * @return OpenCloseEntryList
-     */
-    private function buildOpenChildren(string|null $parentId, array $childrenByParent): array
-    {
-        $key = $parentId ?? '';
-        if (! isset($childrenByParent[$key])) {
-            return [];
-        }
-
-        $result = [];
-        foreach ($childrenByParent[$key] as $op) {
-            $result[] = new OpenCloseEntry(
-                $op->id,
-                $op->type,
-                $op->schemaUrl,
-                $op->context,
-                $this->buildOpenChildren($op->id, $childrenByParent),
-                $op->parentId,
-            );
-        }
-
-        return $result;
-    }
-
-    /**
-     * Build the internal close tree used for profile attachment and tree serialization.
-     *
-     * Closes are still tracked by openId internally even though the public JSON
-     * serializer nests matched closes directly under their open node.
-     *
-     * @return EventEntryList
-     */
-    private function buildNestedClose(bool $includeLive = false): array
-    {
-        $childrenByParent = $this->groupByParent($this->allOpenOperations($includeLive));
-        $closeByOpenId = [];
-        foreach ($this->closeLog as $close) {
-            if ($close->openId !== null) {
-                $closeByOpenId[$close->openId] = $close;
-            }
-        }
-
-        return $this->buildCloseChildren(null, $childrenByParent, $closeByOpenId);
-    }
-
-    /**
-     * @param OpenChildrenByParent      $childrenByParent
-     * @param array<string, EventEntry> $closeByOpenId
-     *
-     * @return EventEntryList
-     */
-    private function buildCloseChildren(string|null $parentId, array $childrenByParent, array $closeByOpenId): array
-    {
-        $key = $parentId ?? '';
-        if (! isset($childrenByParent[$key])) {
-            return [];
-        }
-
-        $result = [];
-        foreach ($childrenByParent[$key] as $op) {
-            $close = $closeByOpenId[$op->id] ?? null;
-            $childCloses = $this->buildCloseChildren($op->id, $childrenByParent, $closeByOpenId);
-            if ($close === null) {
-                foreach ($childCloses as $childClose) {
-                    $result[] = $childClose;
-                }
-
-                continue;
-            }
-
-            $result[] = new EventEntry(
-                $close->id,
-                $close->type,
-                $close->schemaUrl,
-                $close->context,
-                $close->openId,
-                $childCloses,
-                $close->profile,
-            );
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param OpenCloseEntryList $operations
-     *
-     * @return OpenChildrenByParent
-     */
-    private function groupByParent(array $operations): array
-    {
-        $childrenByParent = [];
-        foreach ($operations as $op) {
-            $key = $op->parentId ?? '';
-            $childrenByParent[$key][] = $op;
-        }
-
-        return $childrenByParent;
-    }
-
-    /**
-     * Convert a context object to its stored array shape.
-     *
-     * Prefers `JsonSerializable::jsonSerialize()` when the context implements it,
-     * so callers that need an editorial shape (e.g. emitting empty maps as stdClass
-     * to satisfy `{}` schemas) retain control. Falls back to `(array)` cast for
-     * legacy contexts that rely on public-property introspection.
-     *
-     * @return ContextData
-     */
-    private function contextToArray(AbstractContext $context): array
-    {
-        if ($context instanceof JsonSerializable) {
-            /** @var mixed $serialized */
-            $serialized = $context->jsonSerialize();
-            if (is_array($serialized) && $this->hasOnlyStringKeys($serialized)) {
-                return $this->freezeContext($serialized);
-            }
-        }
-
-        /** @var ContextData $mixedArray */
-        $mixedArray = (array) $context;
-
-        return $this->freezeContext($mixedArray);
-    }
-
-    /** @param array<mixed> $context */
-    private function hasOnlyStringKeys(array $context): bool
-    {
-        foreach (array_keys($context) as $key) {
-            if (! is_string($key)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Freeze user values as an inert JSON tree so later snapshots and flushes
-     * never invoke nested JsonSerializable objects a second time.
-     *
-     * @param array<mixed> $context
-     *
-     * @return ContextData
-     */
-    private function freezeContext(array $context): array
-    {
-        $json = json_encode($context, JSON_THROW_ON_ERROR);
-
-        return $this->contextFromDecoded(json_decode($json, false, 512, JSON_THROW_ON_ERROR));
-    }
-
-    /** @return ContextData */
-    private function contextFromDecoded(mixed $frozen): array
-    {
-        if (is_array($frozen)) {
-            // Only an empty PHP context reaches this JSON-list branch;
-            // non-empty lists are rejected before context freezing.
-            return [];
-        }
-
-        if ($frozen instanceof stdClass) {
-            $properties = get_object_vars($frozen);
-            $keys = array_map(
-                static fn (int|string $key): string => strval($key),
-                array_keys($properties),
-            );
-
-            return array_combine($keys, array_values($properties));
-        }
-
-        return [];
+        return $this->logFromTree($tree, $links, $events);
     }
 
     /**
      * @param SchemaLinks    $links
      * @param EventEntryList $events
      */
-    private function buildLogJson(array $links = [], bool $includeLive = false, array|null $events = null): LogJson
+    private function buildLiveLog(array $links = [], array|null $events = null): LogJson
+    {
+        $tree = $this->logTreeBuilder->includingLive($this->completedOperations, $this->openStack, $this->closeLog);
+
+        return $this->logFromTree($tree, $links, $events);
+    }
+
+    /**
+     * @param LogTree        $tree
+     * @param SchemaLinks    $links
+     * @param EventEntryList $events
+     */
+    private function logFromTree(array $tree, array $links, array|null $events): LogJson
     {
         return new LogJson(
-            self::SEMANTIC_LOG_SCHEMA_URL,
-            $this->buildNestedOpen($includeLive),
-            $this->buildNestedClose($includeLive),
+            CoreSchema::LOG_URL,
+            $tree['open'],
+            $tree['close'],
             $events ?? $this->events,
             $links,
         );
@@ -463,7 +265,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     /** @param SchemaLinks $links */
     private function emptyLog(array $links = []): LogJson
     {
-        return new LogJson(self::SEMANTIC_LOG_SCHEMA_URL, [], [], [], $links);
+        return new LogJson(CoreSchema::LOG_URL, [], [], [], $links);
     }
 
     private function hasSession(): bool
@@ -497,162 +299,6 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         return $type . '_' . (($this->typeCounts[$type] ?? 0) + 1);
     }
 
-    /** @return OpenCloseEntryList */
-    private function allOpenOperations(bool $includeLive): array
-    {
-        $operations = $this->completedOperations;
-        if (! $includeLive) {
-            return $operations;
-        }
-
-        /** @var list<OpenCloseEntry> $liveOperations */
-        $liveOperations = array_reverse(iterator_to_array($this->openStack, false));
-        foreach ($liveOperations as $operation) {
-            $operations[] = $operation;
-        }
-
-        return $operations;
-    }
-
-    /** @return PreparedContext */
-    private function prepareContext(AbstractContext $context, string $operation): array
-    {
-        /** @var mixed $rawType */
-        $rawType = $context::TYPE;
-        /** @var mixed $rawSchemaUrl */
-        $rawSchemaUrl = $context::SCHEMA_URL;
-        /** @var list<DiagnosticData> $diagnostics */
-        $diagnostics = [];
-        $type = is_string($rawType) && $this->isValidType($rawType) ? $rawType : null;
-        $schemaUrl = is_string($rawSchemaUrl) && $this->isValidSchemaUrl($rawSchemaUrl) ? $rawSchemaUrl : null;
-
-        if ($type === null) {
-            if ($this->mode === SemanticLoggerMode::Strict) {
-                throw new InvalidContextTypeException();
-            }
-
-            $diagnostics[] = [
-                'kind' => 'invalid_type',
-                'message' => 'Context TYPE must match ^[a-z_]+$ and must not use the semantic_logger_* namespace.',
-                'originalType' => $this->originalValue($rawType),
-            ];
-        }
-
-        if ($schemaUrl === null) {
-            if ($this->mode === SemanticLoggerMode::Strict) {
-                throw new InvalidSchemaUrlException();
-            }
-
-            $diagnostics[] = [
-                'kind' => 'invalid_schema_url',
-                'message' => 'Context SCHEMA_URL must be an absolute URI or ./schemas/<name>.json.',
-                'originalSchemaUrl' => $this->originalValue($rawSchemaUrl),
-            ];
-        }
-
-        $serialized = [];
-        $serializationSucceeded = false;
-        try {
-            $serialized = $this->contextToArray($context);
-            $serializationSucceeded = true;
-        } catch (Throwable $throwable) {
-            if ($this->mode === SemanticLoggerMode::Strict) {
-                throw $throwable;
-            }
-
-            $diagnostics[] = [
-                'kind' => 'context_serialization_failed',
-                'message' => 'Context serialization failed.',
-                'exceptionClass' => $throwable::class,
-            ];
-        }
-
-        if ($diagnostics === [] && $type !== null && $schemaUrl !== null) {
-            return [
-                'type' => $type,
-                'schemaUrl' => $schemaUrl,
-                'context' => $serialized,
-                'diagnostics' => [],
-            ];
-        }
-
-        if ($serializationSucceeded) {
-            $diagnostics = array_map(static function (array $diagnostic) use ($serialized): array {
-                $diagnostic['discardedContext'] = $serialized;
-
-                return $diagnostic;
-            }, $diagnostics);
-        }
-
-        return [
-            'type' => self::INVALID_CONTEXT_TYPE,
-            'schemaUrl' => self::INVALID_CONTEXT_SCHEMA_URL,
-            'context' => $this->placeholderContext($operation, $diagnostics),
-            'diagnostics' => $diagnostics,
-        ];
-    }
-
-    private function isValidType(mixed $type): bool
-    {
-        if (! is_string($type) || preg_match(self::TYPE_PATTERN, $type) !== 1) {
-            return false;
-        }
-
-        return ! str_starts_with($type, self::RESERVED_TYPE_PREFIX);
-    }
-
-    private function isValidSchemaUrl(mixed $schemaUrl): bool
-    {
-        if (! is_string($schemaUrl) || $schemaUrl === '') {
-            return false;
-        }
-
-        if (preg_match(self::RELATIVE_SCHEMA_PATTERN, $schemaUrl) === 1) {
-            return true;
-        }
-
-        $scheme = parse_url($schemaUrl, PHP_URL_SCHEME);
-
-        return is_string($scheme) && preg_match(self::URI_SCHEME_PATTERN, $scheme) === 1;
-    }
-
-    /**
-     * @param list<DiagnosticData> $diagnostics
-     *
-     * @return ContextData
-     */
-    private function placeholderContext(string $operation, array $diagnostics): array
-    {
-        $errors = array_map(
-            static fn (array $diagnostic): array => [
-                'kind' => $diagnostic['kind'],
-                'message' => $diagnostic['message'],
-            ],
-            $diagnostics,
-        );
-        $context = [
-            'operation' => $operation,
-            'errors' => $errors,
-        ];
-
-        foreach ($diagnostics as $diagnostic) {
-            if (isset($diagnostic['originalType'])) {
-                $context['originalType'] = $diagnostic['originalType'];
-            }
-
-            if (isset($diagnostic['originalSchemaUrl'])) {
-                $context['originalSchemaUrl'] = $diagnostic['originalSchemaUrl'];
-            }
-        }
-
-        return $context;
-    }
-
-    private function originalValue(mixed $value): string
-    {
-        return is_string($value) ? $value : get_debug_type($value);
-    }
-
     /**
      * @param list<DiagnosticData> $diagnostics
      *
@@ -679,9 +325,9 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
     private function diagnosticEntry(array $diagnostic, string|null $openId, string|null $id = null): EventEntry
     {
         return new EventEntry(
-            $id ?? $this->nextId(self::DIAGNOSTIC_TYPE),
-            self::DIAGNOSTIC_TYPE,
-            self::DIAGNOSTIC_SCHEMA_URL,
+            $id ?? $this->nextId(CoreSchema::DIAGNOSTIC_TYPE),
+            CoreSchema::DIAGNOSTIC_TYPE,
+            CoreSchema::DIAGNOSTIC_URL,
             $diagnostic,
             $openId,
         );
@@ -702,7 +348,7 @@ final class SemanticLogger implements SemanticLoggerInterface, JsonSerializable
         ];
 
         try {
-            $diagnostic['discardedContext'] = $this->contextToArray($context);
+            $diagnostic['discardedContext'] = $this->contextPreparer->freezeContext($context);
         } catch (Throwable $throwable) {
             $diagnostic['exceptionClass'] = $throwable::class;
         }

--- a/src/SemanticLoggerInterface.php
+++ b/src/SemanticLoggerInterface.php
@@ -11,7 +11,8 @@ interface SemanticLoggerInterface
      * Start a new hierarchical operation context
      *
      * Opens a new logging context that can contain nested operations and events.
-     * Returns a type-based unique ID that must be used to close this operation.
+     * Returns a non-empty, protocol-valid, per-session unique ID that must be
+     * used to close this operation.
      *
      * @return string Type-based operation ID (e.g., "user_registration_1") for closing this operation
      */
@@ -21,7 +22,8 @@ interface SemanticLoggerInterface
      * Log an event within the current operation context
      *
      * Records events that occur during the execution of an open operation.
-     * Events are associated with the currently active operation context.
+     * Events are associated with the currently active operation context, or
+     * with the session root when no operation is open (an event-only session).
      */
     public function event(AbstractContext $context): void;
 
@@ -39,9 +41,9 @@ interface SemanticLoggerInterface
     /**
      * Get the complete log data and reset the logger state
      *
-     * Returns the entire log session as a structured LogJson object and resets
-     * the internal state for the next logging session. This implements the
-     * flush pattern for one-time log consumption.
+     * Returns the entire log session as a structured LogJson object. Every
+     * flush attempt resets internal state for the next logging session, even
+     * when strict mode reports the session by throwing an exception.
      *
      * @param SchemaLinks $links Optional links for complete system transparency
      */

--- a/src/SemanticLoggerMode.php
+++ b/src/SemanticLoggerMode.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Koriym\SemanticLogger;
 
-enum SemanticLoggerMode
+enum SemanticLoggerMode: string
 {
-    case Strict;
-    case Total;
+    case Strict = 'strict';
+    case Total = 'total';
 }

--- a/src/SemanticLoggerMode.php
+++ b/src/SemanticLoggerMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+enum SemanticLoggerMode
+{
+    case Strict;
+    case Total;
+}

--- a/src/Types.php
+++ b/src/Types.php
@@ -48,6 +48,23 @@ namespace Koriym\SemanticLogger;
  * @psalm-type OperationIdSet = array<OperationId, true>
  * @psalm-type TypeCounts = array<LogType, int>
  * @psalm-type SchemaTypeMap = array<LogType, string>
+ * @psalm-type DiagnosticKind = 'invalid_type'|'invalid_schema_url'|'context_serialization_failed'|'close_without_open'|'close_id_mismatch'|'unclosed_at_flush'
+ * @psalm-type DiagnosticData = array{
+ *     kind: DiagnosticKind,
+ *     message: string,
+ *     exceptionClass?: string,
+ *     relatedId?: string,
+ *     originalType?: string,
+ *     originalSchemaUrl?: string,
+ *     discardedContext?: ContextData,
+ *     unclosedIds?: list<OperationId>
+ * }
+ * @psalm-type PreparedContext = array{
+ *     type: LogType,
+ *     schemaUrl: SchemaUrl,
+ *     context: ContextData,
+ *     diagnostics: list<DiagnosticData>
+ * }
  *
  * Serialized log entry types
  * @psalm-type EventEntryArray = array{
@@ -98,73 +115,6 @@ namespace Koriym\SemanticLogger;
  *     close?: array<array-key, PublicCloseEntry>,
  *     links?: SchemaLinks
  * }
- *
- * MCP types
- * @psalm-type McpJsonRpcError = array{
- *     code: int,
- *     message: string
- * }
- * @psalm-type McpServerInfo = array{
- *     name: string,
- *     version: string
- * }
- * @psalm-type McpCapabilities = array{
- *     tools: object
- * }
- * @psalm-type McpInitializeResult = array{
- *     protocolVersion: string,
- *     serverInfo: McpServerInfo,
- *     capabilities: McpCapabilities
- * }
- * @psalm-type McpPropertySchema = array{
- *     type: string,
- *     description?: string,
- *     default?: string
- * }
- * @psalm-type McpInputSchema = array{
- *     type: string,
- *     properties: object|array<string, McpPropertySchema>,
- *     required?: list<string>
- * }
- * @psalm-type McpTool = array{
- *     name: string,
- *     description: string,
- *     inputSchema: McpInputSchema
- * }
- * @psalm-type McpToolsList = list<McpTool>
- * @psalm-type McpToolsListResult = array{
- *     tools: McpToolsList
- * }
- * @psalm-type McpContent = array{
- *     type: string,
- *     text: string
- * }
- * @psalm-type McpContentList = list<McpContent>
- * @psalm-type McpToolCallResult = array{
- *     content: McpContentList,
- *     isError: bool
- * }
- * @psalm-type McpJsonRpcResponse = array{
- *     jsonrpc: string,
- *     id: int|string|null,
- *     result?: McpInitializeResult|McpToolsListResult|McpToolCallResult,
- *     error?: McpJsonRpcError
- * }
- * @psalm-type McpJsonRpcRequest = array{
- *     jsonrpc: string,
- *     method: string,
- *     id?: int|string|null,
- *     params?: array<string, mixed>
- * }
- * @psalm-type McpToolCallParams = array{
- *     name: string,
- *     arguments?: JsonMap
- * }
- * @psalm-type McpSemanticAnalyzeArgs = array{
- *     script?: string,
- *     xdebug_mode?: string
- * }
- * @psalm-type McpLogData = JsonMap
  * @phpcs:enable
  */
 final class Types

--- a/src/Types.php
+++ b/src/Types.php
@@ -123,6 +123,7 @@ namespace Koriym\SemanticLogger;
  * @psalm-type CloseEntryArray = PublicCloseEntry
  * @psalm-type LogSessionArray = array{
  *     '$schema': SchemaUrl,
+ *     mode?: 'strict'|'total',
  *     open: list<PublicOpenEntry>,
  *     events?: list<PublicEventEntry>,
  *     close?: array<array-key, PublicCloseEntry>,

--- a/src/Types.php
+++ b/src/Types.php
@@ -65,6 +65,19 @@ namespace Koriym\SemanticLogger;
  *     context: ContextData,
  *     diagnostics: list<DiagnosticData>
  * }
+ * @psalm-type PreparedMetadata = array{
+ *     type: LogType|null,
+ *     schemaUrl: SchemaUrl|null,
+ *     diagnostics: list<DiagnosticData>
+ * }
+ * @psalm-type PreparedSerialization = array{
+ *     context: ContextData|null,
+ *     diagnostics: list<DiagnosticData>
+ * }
+ * @psalm-type LogTree = array{
+ *     open: OpenCloseEntryList,
+ *     close: EventEntryList
+ * }
  *
  * Serialized log entry types
  * @psalm-type EventEntryArray = array{

--- a/tests/DevSemanticLoggerTest.php
+++ b/tests/DevSemanticLoggerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Koriym\SemanticLogger;
 
+use Koriym\SemanticLogger\Profiler\PhpProfile;
 use Koriym\SemanticLogger\Profiler\XdebugTrace;
 use Koriym\SemanticLogger\Profiler\XHProfResult;
 use PHPUnit\Framework\TestCase;
@@ -162,6 +163,59 @@ final class DevSemanticLoggerTest extends TestCase
         $this->assertCount(1, $second->close);
         $this->assertSame($id1, $first->close[0]->openId);
         $this->assertSame($id2, $second->close[0]->openId);
+    }
+
+    public function testStrictCloseFailureKeepsProfilerAndInnerStacksRetryable(): void
+    {
+        $openId = $this->logger->open(new FakeContext('start'));
+        $reflection = new ReflectionClass($this->logger);
+        /** @var array<string, PhpProfile> $startedPhp */
+        $startedPhp = $reflection->getProperty('startedPhp')->getValue($this->logger);
+        $initialProfile = $startedPhp[$openId];
+
+        try {
+            $this->logger->close(new ModeThrowingContext(), $openId);
+            $this->fail('Expected serialization failure.');
+        } catch (ModeTestSerializationException) {
+        }
+
+        /** @var array<string, PhpProfile> $startedPhp */
+        $startedPhp = $reflection->getProperty('startedPhp')->getValue($this->logger);
+        $this->assertNotSame($initialProfile, $startedPhp[$openId]);
+
+        $this->logger->close(new FakeContext('done'), $openId);
+        $array = $this->logger->flush()->toArray();
+
+        $this->assertSame($openId, $array['open'][0]['id']);
+        $this->assertSame('example_event_2', $this->firstSerializedClose($array)['id']);
+    }
+
+    public function testTotalWrongCloseIdDoesNotCorruptProfilerStack(): void
+    {
+        $logger = new DevSemanticLogger(new SemanticLogger(SemanticLoggerMode::Total));
+        $outerId = $logger->open(new FakeContext('outer'));
+        $innerId = $logger->open(new FakeContext('inner'));
+
+        $logger->close(new FakeContext('wrong order'), $outerId);
+        $logger->close(new FakeContext('inner close'), $innerId);
+        $logger->close(new FakeContext('outer close'), $outerId);
+
+        $array = $logger->flush()->toArray();
+        $this->assertSame($outerId, $array['open'][0]['id']);
+        $this->assertSame($innerId, $this->valueAt($array, 'open', 0, 'open', 0, 'id'));
+        $this->assertSame('close_id_mismatch', $this->valueAt($array, 'open', 0, 'open', 0, 'events', 0, 'context', 'kind'));
+    }
+
+    public function testTotalCloseFailureCommitsPlaceholderWithProfileTopologyIntact(): void
+    {
+        $logger = new DevSemanticLogger(new SemanticLogger(SemanticLoggerMode::Total));
+        $openId = $logger->open(new FakeContext('start'));
+
+        $logger->close(new ModeThrowingContext(), $openId);
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('semantic_logger_invalid_context', $this->firstSerializedClose($array)['type']);
+        $this->assertSame('context_serialization_failed', $this->valueAt($array, 'open', 0, 'events', 0, 'context', 'kind'));
     }
 
     public function testDevStateIsResetEvenWhenInnerFlushThrows(): void
@@ -412,5 +466,18 @@ final class DevSemanticLoggerTest extends TestCase
         }
 
         return $normalized;
+    }
+
+    /** @param array<array-key, mixed> $array */
+    private function valueAt(array $array, int|string ...$path): mixed
+    {
+        $value = $array;
+        foreach ($path as $key) {
+            $this->assertIsArray($value);
+            $this->assertArrayHasKey($key, $value);
+            $value = $value[$key];
+        }
+
+        return $value;
     }
 }

--- a/tests/DevSemanticLoggerTest.php
+++ b/tests/DevSemanticLoggerTest.php
@@ -60,6 +60,27 @@ final class DevSemanticLoggerTest extends TestCase
         $this->assertCount(1, $xhprofSegments[$inner]);
     }
 
+    public function testFlushPreservesInnerLoggerModeInEnvelope(): void
+    {
+        $openId = $this->logger->open(new FakeContext('test'));
+        $this->logger->close(new FakeContext('done'), $openId);
+
+        $array = $this->logger->flush()->toArray();
+
+        $this->assertSame('strict', $array['mode'] ?? null);
+    }
+
+    public function testFlushPreservesTotalModeFromInnerLogger(): void
+    {
+        $logger = new DevSemanticLogger(new SemanticLogger(SemanticLoggerMode::Total));
+        $openId = $logger->open(new FakeContext('test'));
+        $logger->close(new FakeContext('done'), $openId);
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('total', $array['mode'] ?? null);
+    }
+
     public function testProfileIsOmittedFromJsonOutputWithoutProfilerData(): void
     {
         $openId = $this->logger->open(new FakeContext('test'));

--- a/tests/DynamicSchemaGeneratorTest.php
+++ b/tests/DynamicSchemaGeneratorTest.php
@@ -53,13 +53,16 @@ final class DynamicSchemaGeneratorTest extends TestCase
         $openProperty = $this->expectArray($properties['open'] ?? null);
         $eventsProperty = $this->expectArray($properties['events'] ?? null);
         $closeProperty = $this->expectArray($properties['close'] ?? null);
+        $contextType = $this->expectArray($definitions['contextType'] ?? null);
 
         $this->assertSame(['$schema', 'open'], $schema['required']);
         $this->assertArrayHasKey('$schema', $properties);
         $this->assertArrayNotHasKey('schemaUrl', $properties);
         $this->assertSame('array', $openProperty['type']);
+        $this->assertArrayNotHasKey('minItems', $openProperty);
         $this->assertSame('array', $eventsProperty['type']);
         $this->assertSame('array', $closeProperty['type']);
+        $this->assertSame('^[a-z_]+$', $contextType['pattern']);
 
         $this->assertOpenEntryDefinition($definitions['openEntry'] ?? null);
         $this->assertLeafEntryDefinition($definitions['eventEntry'] ?? null);

--- a/tests/DynamicSchemaGeneratorTest.php
+++ b/tests/DynamicSchemaGeneratorTest.php
@@ -103,6 +103,7 @@ final class DynamicSchemaGeneratorTest extends TestCase
         $this->assertArrayHasKey('open', $properties);
         $this->assertArrayHasKey('events', $properties);
         $this->assertArrayHasKey('close', $properties);
+        $this->assertSame('#/definitions/contextType', $this->expectArray($properties['type'] ?? null)['$ref']);
 
         $this->assertCount(2, $allOf);
 
@@ -138,6 +139,7 @@ final class DynamicSchemaGeneratorTest extends TestCase
         $this->assertArrayNotHasKey('events', $properties);
         $this->assertArrayNotHasKey('close', $properties);
         $this->assertArrayHasKey('openId', $properties);
+        $this->assertSame('#/definitions/contextType', $this->expectArray($properties['type'] ?? null)['$ref']);
 
         if ($allowsProfile) {
             $this->assertArrayHasKey('profile', $properties);

--- a/tests/Fake/ModeInvalidMetadataContext.php
+++ b/tests/Fake/ModeInvalidMetadataContext.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class ModeInvalidMetadataContext extends AbstractContext
+{
+    public const TYPE = 'Invalid-Type';
+    public const SCHEMA_URL = 'invalid-schema';
+
+    public string $message = 'discarded';
+}

--- a/tests/Fake/ModeInvalidSchemaContext.php
+++ b/tests/Fake/ModeInvalidSchemaContext.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class ModeInvalidSchemaContext extends AbstractContext
+{
+    public const TYPE = 'mode_context';
+    public const SCHEMA_URL = 'invalid-schema';
+}

--- a/tests/Fake/ModeInvalidTypeContext.php
+++ b/tests/Fake/ModeInvalidTypeContext.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class ModeInvalidTypeContext extends AbstractContext
+{
+    public const TYPE = 'Invalid-Type';
+    public const SCHEMA_URL = './schemas/mode-context.json';
+}

--- a/tests/Fake/ModeReservedContext.php
+++ b/tests/Fake/ModeReservedContext.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class ModeReservedContext extends AbstractContext
+{
+    public const TYPE = 'semantic_logger_consumer';
+    public const SCHEMA_URL = './schemas/mode-context.json';
+}

--- a/tests/Fake/ModeTestContext.php
+++ b/tests/Fake/ModeTestContext.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+final class ModeTestContext extends AbstractContext
+{
+    public const TYPE = 'mode_context';
+    public const SCHEMA_URL = './schemas/mode-context.json';
+    public const ROOT_SCHEMA = 'https://koriym.github.io/Koriym.SemanticLogger/schemas/semantic-log.json';
+
+    public function __construct(public readonly string $message)
+    {
+    }
+}

--- a/tests/Fake/ModeTestSerializationException.php
+++ b/tests/Fake/ModeTestSerializationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use RuntimeException;
+
+final class ModeTestSerializationException extends RuntimeException
+{
+}

--- a/tests/Fake/ModeThrowingContext.php
+++ b/tests/Fake/ModeThrowingContext.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use JsonSerializable;
+use Override;
+
+final class ModeThrowingContext extends AbstractContext implements JsonSerializable
+{
+    public const TYPE = 'mode_context';
+    public const SCHEMA_URL = './schemas/mode-context.json';
+
+    #[Override]
+    public function jsonSerialize(): mixed
+    {
+        throw new ModeTestSerializationException('Cannot serialize test context.');
+    }
+}

--- a/tests/NullSemanticLoggerTest.php
+++ b/tests/NullSemanticLoggerTest.php
@@ -27,6 +27,9 @@ final class NullSemanticLoggerTest extends TestCase
         $this->assertSame([], $log->close);
         $this->assertSame([], $log->events);
 
+        // A null log proves nothing about how it was produced, so it must not claim a mode.
+        $this->assertArrayNotHasKey('mode', $log->toArray());
+
         $this->assertSame('noop_1', $logger->open(new FakeContext('next session')));
     }
 }

--- a/tests/NullSemanticLoggerTest.php
+++ b/tests/NullSemanticLoggerTest.php
@@ -12,16 +12,21 @@ final class NullSemanticLoggerTest extends TestCase
     {
         $logger = new NullSemanticLogger();
 
-        $openId = $logger->open(new FakeContext('open'));
-        $this->assertSame('', $openId, 'open() returns an empty id meaning "no close needed"');
+        $firstOpenId = $logger->open(new FakeContext('open'));
+        $secondOpenId = $logger->open(new FakeContext('nested'));
+        $this->assertSame('noop_1', $firstOpenId);
+        $this->assertSame('noop_2', $secondOpenId);
 
         // event() and close() are no-ops and must not throw or change the (empty) session.
         $logger->event(new FakeContext('event'));
-        $logger->close(new FakeContext('close'), $openId);
+        $logger->close(new FakeContext('close'), $secondOpenId);
+        $logger->close(new FakeContext('close'), $firstOpenId);
 
         $log = $logger->flush();
         $this->assertSame([], $log->open);
         $this->assertSame([], $log->close);
         $this->assertSame([], $log->events);
+
+        $this->assertSame('noop_1', $logger->open(new FakeContext('next session')));
     }
 }

--- a/tests/SemanticLogValidatorTest.php
+++ b/tests/SemanticLogValidatorTest.php
@@ -184,6 +184,38 @@ JSON,
         $this->validator->validate($this->logFile, $this->schemaDirectory);
     }
 
+    public function testValidateRejectsUnsupportedCoreDiagnosticKind(): void
+    {
+        file_put_contents(
+            $this->logFile,
+            json_encode([
+                '$schema' => CoreSchema::LOG_URL,
+                'open' => [],
+                'events' => [
+                    [
+                        'id' => 'semantic_logger_invalid_context_1',
+                        'type' => CoreSchema::INVALID_CONTEXT_TYPE,
+                        'schemaUrl' => CoreSchema::INVALID_CONTEXT_URL,
+                        'context' => [
+                            'operation' => 'event',
+                            'errors' => [
+                                [
+                                    'kind' => 'unsupported_kind',
+                                    'message' => 'invalid protocol value',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectOutputRegex('/semantic_logger_invalid_context.*enumeration/s');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+
     public function testValidateAcceptsEmptyDiscardedContextInCoreDiagnostic(): void
     {
         $logger = new SemanticLogger(SemanticLoggerMode::Total);

--- a/tests/SemanticLogValidatorTest.php
+++ b/tests/SemanticLogValidatorTest.php
@@ -11,11 +11,14 @@ use RuntimeException;
 use function file_exists;
 use function file_put_contents;
 use function is_dir;
+use function json_encode;
 use function mkdir;
 use function rmdir;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
+
+use const JSON_THROW_ON_ERROR;
 
 final class SemanticLogValidatorTest extends TestCase
 {
@@ -158,6 +161,42 @@ JSON,
 
         $this->expectException(RuntimeException::class);
         $this->expectOutputRegex('/open\[0\]\.id|regex pattern/');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+
+    public function testValidateUsesBundledSchemasForTotalModeDiagnostics(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event(new class extends AbstractContext {
+            public const TYPE = 'Invalid-Type';
+            public const SCHEMA_URL = './schemas/not-used.json';
+
+            public string $value = 'kept in diagnostics';
+        });
+        file_put_contents(
+            $this->logFile,
+            json_encode($logger->flush()->toArray(), JSON_THROW_ON_ERROR),
+        );
+
+        $this->expectOutputRegex('/semantic_logger_invalid_context.*semantic_logger_error.*All contexts validate successfully/s');
+        self::assertNotNull($this->validator);
+        $this->validator->validate($this->logFile, $this->schemaDirectory);
+    }
+
+    public function testValidateAcceptsEmptyDiscardedContextInCoreDiagnostic(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->close(new class extends AbstractContext {
+            public const TYPE = 'empty_context';
+            public const SCHEMA_URL = './schemas/not-used.json';
+        }, 'missing_1');
+        file_put_contents(
+            $this->logFile,
+            json_encode($logger->flush()->toArray(), JSON_THROW_ON_ERROR),
+        );
+
+        $this->expectOutputRegex('/semantic_logger_error.*All contexts validate successfully/s');
         self::assertNotNull($this->validator);
         $this->validator->validate($this->logFile, $this->schemaDirectory);
     }

--- a/tests/SemanticLoggerModeTest.php
+++ b/tests/SemanticLoggerModeTest.php
@@ -337,8 +337,8 @@ final class SemanticLoggerModeTest extends TestCase
     {
         $logger = new SemanticLogger(SemanticLoggerMode::Total);
 
-        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'open' => []], $logger->flush()->toArray());
-        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'open' => []], $logger->flush()->toArray());
+        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'mode' => 'total', 'open' => []], $logger->flush()->toArray());
+        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'mode' => 'total', 'open' => []], $logger->flush()->toArray());
 
         $logger->event(new ModeTestContext('event'));
         $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
@@ -387,6 +387,26 @@ final class SemanticLoggerModeTest extends TestCase
         $flushed = $logger->flush()->toArray();
         $this->assertCount(1, $this->arrayAt($flushed, 'events'));
         $this->assertSame('semantic_logger_error_1', $this->valueAt($flushed, 'events', 0, 'id'));
+    }
+
+    public function testStrictFlushRecordsModeInEnvelope(): void
+    {
+        $logger = new SemanticLogger();
+        $logger->event(new ModeTestContext('event'));
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('strict', $array['mode'] ?? null);
+    }
+
+    public function testTotalFlushRecordsModeInEnvelope(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event(new ModeTestContext('event'));
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('total', $array['mode'] ?? null);
     }
 
     /** @param array<array-key, mixed> $array */

--- a/tests/SemanticLoggerModeTest.php
+++ b/tests/SemanticLoggerModeTest.php
@@ -1,0 +1,417 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\SemanticLogger;
+
+use JsonSerializable;
+use Koriym\SemanticLogger\Exception\InvalidContextTypeException;
+use Koriym\SemanticLogger\Exception\InvalidOperationOrderException;
+use Koriym\SemanticLogger\Exception\InvalidSchemaUrlException;
+use Koriym\SemanticLogger\Exception\NoLogSessionException;
+use Koriym\SemanticLogger\Exception\NoOpenOperationsException;
+use Koriym\SemanticLogger\Exception\UnclosedLogicException;
+use Override;
+use PHPUnit\Framework\TestCase;
+
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+final class SemanticLoggerModeTest extends TestCase
+{
+    public function testStrictIsTheDefaultAndAcceptsEventOnlySessions(): void
+    {
+        $logger = new SemanticLogger();
+        $logger->event(new ModeTestContext('event'));
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame([], $array['open']);
+        $this->assertSame('mode_context_1', $this->valueAt($array, 'events', 0, 'id'));
+    }
+
+    public function testStrictInvalidTypeThrowsWithoutAdvancingIds(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->open(new ModeInvalidTypeContext());
+            $this->fail('Invalid TYPE must throw in strict mode.');
+        } catch (InvalidContextTypeException) {
+        }
+
+        $openId = $logger->open(new ModeTestContext('open'));
+        $this->assertSame('mode_context_1', $openId);
+        $logger->close(new ModeTestContext('close'), $openId);
+        $logger->flush();
+    }
+
+    public function testStrictInvalidSchemaUrlThrowsWithoutAdvancingIds(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->event(new ModeInvalidSchemaContext());
+            $this->fail('Invalid SCHEMA_URL must throw in strict mode.');
+        } catch (InvalidSchemaUrlException) {
+        }
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testStrictReservedNamespaceThrows(): void
+    {
+        $logger = new SemanticLogger();
+
+        $this->expectException(InvalidContextTypeException::class);
+        $logger->event(new ModeReservedContext());
+    }
+
+    public function testStrictOpenSerializationFailureDoesNotAdvanceIds(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->open(new ModeThrowingContext());
+            $this->fail('Serialization failure must escape strict mode.');
+        } catch (ModeTestSerializationException) {
+        }
+
+        $openId = $logger->open(new ModeTestContext('open'));
+        $this->assertSame('mode_context_1', $openId);
+        $logger->close(new ModeTestContext('close'), $openId);
+        $logger->flush();
+    }
+
+    public function testStrictEventSerializationFailureDoesNotAdvanceIds(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->event(new ModeThrowingContext());
+            $this->fail('Serialization failure must escape strict mode.');
+        } catch (ModeTestSerializationException) {
+        }
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testStrictCloseWithoutOpenDoesNotAdvanceIds(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->close(new ModeTestContext('rejected close'), 'missing_1');
+            $this->fail('Close without open must throw in strict mode.');
+        } catch (NoOpenOperationsException) {
+        }
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testStrictWrongCloseIdPreservesStack(): void
+    {
+        $logger = new SemanticLogger();
+        $openId = $logger->open(new ModeTestContext('open'));
+
+        try {
+            $logger->close(new ModeTestContext('rejected close'), 'wrong_1');
+            $this->fail('Wrong close id must throw in strict mode.');
+        } catch (InvalidOperationOrderException) {
+        }
+
+        $logger->close(new ModeTestContext('close'), $openId);
+        $array = $logger->flush()->toArray();
+        $this->assertSame('mode_context_2', $this->valueAt($array, 'open', 0, 'close', 'id'));
+    }
+
+    public function testStrictCloseSerializationFailurePreservesStackAndIdCounter(): void
+    {
+        $logger = new SemanticLogger();
+        $openId = $logger->open(new ModeTestContext('open'));
+
+        try {
+            $logger->close(new ModeThrowingContext(), $openId);
+            $this->fail('Serialization failure must escape strict mode.');
+        } catch (ModeTestSerializationException) {
+        }
+
+        $logger->close(new ModeTestContext('close'), $openId);
+        $array = $logger->flush()->toArray();
+        $this->assertSame('mode_context_2', $this->valueAt($array, 'open', 0, 'close', 'id'));
+    }
+
+    public function testStrictSessionlessFlushThrowsAndResets(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->flush();
+            $this->fail('Sessionless strict flush must throw.');
+        } catch (NoLogSessionException) {
+        }
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testStrictUnclosedFlushThrowsAndResets(): void
+    {
+        $logger = new SemanticLogger();
+        $logger->open(new ModeTestContext('first session'));
+
+        try {
+            $logger->flush();
+            $this->fail('Unclosed strict flush must throw.');
+        } catch (UnclosedLogicException) {
+        }
+
+        $openId = $logger->open(new ModeTestContext('second session'));
+        $this->assertSame('mode_context_1', $openId);
+        $logger->close(new ModeTestContext('close'), $openId);
+        $logger->flush();
+    }
+
+    public function testStrictUnclosedSnapshotThrowsWithoutReset(): void
+    {
+        $logger = new SemanticLogger();
+        $openId = $logger->open(new ModeTestContext('open'));
+
+        try {
+            $logger->toArray();
+            $this->fail('Unclosed strict snapshot must throw.');
+        } catch (UnclosedLogicException) {
+        }
+
+        $logger->close(new ModeTestContext('close'), $openId);
+        $this->assertSame($openId, $logger->flush()->toArray()['open'][0]['id']);
+    }
+
+    public function testStrictSessionlessSnapshotThrowsWithoutStartingSession(): void
+    {
+        $logger = new SemanticLogger();
+
+        try {
+            $logger->toArray();
+            $this->fail('Sessionless strict snapshot must throw.');
+        } catch (NoLogSessionException) {
+        }
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testTotalInvalidMetadataCommitsPlaceholderAndDiagnostics(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event(new ModeInvalidMetadataContext());
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame([], $array['open']);
+        $this->assertSame('semantic_logger_invalid_context', $this->valueAt($array, 'events', 0, 'type'));
+        $this->assertSame('event', $this->valueAt($array, 'events', 0, 'context', 'operation'));
+        $this->assertSame('Invalid-Type', $this->valueAt($array, 'events', 0, 'context', 'originalType'));
+        $this->assertSame('invalid-schema', $this->valueAt($array, 'events', 0, 'context', 'originalSchemaUrl'));
+        $this->assertSame('invalid_type', $this->valueAt($array, 'events', 1, 'context', 'kind'));
+        $this->assertSame('invalid_schema_url', $this->valueAt($array, 'events', 2, 'context', 'kind'));
+    }
+
+    public function testTotalReservedNamespaceCommitsFallback(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event(new ModeReservedContext());
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('semantic_logger_invalid_context', $this->valueAt($array, 'events', 0, 'type'));
+        $this->assertSame('semantic_logger_consumer', $this->valueAt($array, 'events', 1, 'context', 'originalType'));
+    }
+
+    public function testTotalOpenSerializationFailureReturnsProtocolValidPlaceholderId(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $openId = $logger->open(new ModeThrowingContext());
+        $logger->close(new ModeTestContext('close'), $openId);
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('semantic_logger_invalid_context_1', $openId);
+        $this->assertSame($openId, $array['open'][0]['id']);
+        $this->assertSame('context_serialization_failed', $this->valueAt($array, 'open', 0, 'events', 0, 'context', 'kind'));
+    }
+
+    public function testTotalEventSerializationFailureCommitsPlaceholderAndDiagnostic(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event(new ModeThrowingContext());
+
+        $events = $this->arrayAt($logger->flush()->toArray(), 'events');
+
+        $this->assertSame('semantic_logger_invalid_context', $this->valueAt($events, 0, 'type'));
+        $this->assertSame('context_serialization_failed', $this->valueAt($events, 1, 'context', 'kind'));
+        $this->assertSame(ModeTestSerializationException::class, $this->valueAt($events, 1, 'context', 'exceptionClass'));
+        $this->assertArrayNotHasKey('discardedContext', $this->arrayAt($events, 1, 'context'));
+    }
+
+    public function testTotalDiagnosticFreezesNestedSerializableValues(): void
+    {
+        $value = new class implements JsonSerializable {
+            public int $calls = 0;
+
+            #[Override]
+            public function jsonSerialize(): mixed
+            {
+                $this->calls++;
+                if ($this->calls > 1) {
+                    throw new ModeTestSerializationException('Nested value serialized more than once.');
+                }
+
+                return ['stable' => true];
+            }
+        };
+        $context = new class ($value) extends AbstractContext {
+            public const TYPE = 'Invalid-Type';
+            public const SCHEMA_URL = './schemas/mode-context.json';
+
+            public function __construct(public readonly JsonSerializable $value)
+            {
+            }
+        };
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->event($context);
+
+        $json = json_encode($logger->flush()->toArray(), JSON_THROW_ON_ERROR);
+
+        $this->assertStringContainsString('"stable":true', $json);
+        $this->assertSame(1, $value->calls);
+    }
+
+    public function testTotalCloseWithoutOpenRecordsEventOnlyDiagnostic(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $logger->close(new ModeTestContext('rejected close'), 'missing_1');
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame([], $array['open']);
+        $this->assertSame('close_without_open', $this->valueAt($array, 'events', 0, 'context', 'kind'));
+        $this->assertSame('missing_1', $this->valueAt($array, 'events', 0, 'context', 'relatedId'));
+        $this->assertSame(['message' => 'rejected close'], $this->valueAt($array, 'events', 0, 'context', 'discardedContext'));
+    }
+
+    public function testTotalWrongCloseIdPreservesOpenAndFlushReportsItUnclosed(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $openId = $logger->open(new ModeTestContext('open'));
+        $logger->close(new ModeTestContext('rejected close'), 'wrong_1');
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame($openId, $array['open'][0]['id']);
+        $this->assertArrayNotHasKey('close', $this->arrayAt($array, 'open', 0));
+        $this->assertSame('close_id_mismatch', $this->valueAt($array, 'open', 0, 'events', 0, 'context', 'kind'));
+        $this->assertSame('unclosed_at_flush', $this->valueAt($array, 'events', 0, 'context', 'kind'));
+        $this->assertSame([$openId], $this->valueAt($array, 'events', 0, 'context', 'unclosedIds'));
+    }
+
+    public function testTotalValidCloseSerializationFailurePopsAndCommitsPlaceholder(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $openId = $logger->open(new ModeTestContext('open'));
+        $logger->close(new ModeThrowingContext(), $openId);
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame('semantic_logger_invalid_context', $this->valueAt($array, 'open', 0, 'close', 'type'));
+        $this->assertSame('close', $this->valueAt($array, 'open', 0, 'close', 'context', 'operation'));
+        $this->assertSame('context_serialization_failed', $this->valueAt($array, 'open', 0, 'events', 0, 'context', 'kind'));
+        $this->assertArrayNotHasKey('events', $array);
+    }
+
+    public function testTotalSessionlessFlushIsIdempotentAndResetsCounter(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+
+        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'open' => []], $logger->flush()->toArray());
+        $this->assertSame(['$schema' => ModeTestContext::ROOT_SCHEMA, 'open' => []], $logger->flush()->toArray());
+
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testTotalUnclosedFlushIncludesLiveTopologyAndResets(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $outerId = $logger->open(new ModeTestContext('outer'));
+        $childId = $logger->open(new ModeTestContext('child'));
+        $logger->close(new ModeTestContext('child close'), $childId);
+
+        $array = $logger->flush()->toArray();
+
+        $this->assertSame($outerId, $array['open'][0]['id']);
+        $this->assertSame($childId, $this->valueAt($array, 'open', 0, 'open', 0, 'id'));
+        $this->assertSame('mode_context_3', $this->valueAt($array, 'open', 0, 'open', 0, 'close', 'id'));
+        $this->assertArrayNotHasKey('close', $this->arrayAt($array, 'open', 0));
+        $this->assertSame([$outerId], $this->valueAt($array, 'events', 0, 'context', 'unclosedIds'));
+
+        $nextId = $logger->open(new ModeTestContext('next session'));
+        $this->assertSame('mode_context_1', $nextId);
+    }
+
+    public function testTotalSessionlessSnapshotIsEmptyAndNonDestructive(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+
+        $this->assertSame($logger->toArray(), $logger->toArray());
+        $logger->event(new ModeTestContext('event'));
+        $this->assertSame('mode_context_1', $this->valueAt($logger->flush()->toArray(), 'events', 0, 'id'));
+    }
+
+    public function testTotalUnclosedSnapshotsDoNotAccumulateDiagnostics(): void
+    {
+        $logger = new SemanticLogger(SemanticLoggerMode::Total);
+        $openId = $logger->open(new ModeTestContext('open'));
+
+        $first = $logger->toArray();
+        $second = $logger->toArray();
+
+        $this->assertSame($first, $second);
+        $this->assertSame($openId, $first['open'][0]['id']);
+        $this->assertSame('unclosed_at_flush', $this->valueAt($first, 'events', 0, 'context', 'kind'));
+
+        $flushed = $logger->flush()->toArray();
+        $this->assertCount(1, $this->arrayAt($flushed, 'events'));
+        $this->assertSame('semantic_logger_error_1', $this->valueAt($flushed, 'events', 0, 'id'));
+    }
+
+    /** @param array<array-key, mixed> $array */
+    private function valueAt(array $array, int|string ...$path): mixed
+    {
+        $value = $array;
+        foreach ($path as $key) {
+            $this->assertIsArray($value);
+            $this->assertArrayHasKey($key, $value);
+            $value = $value[$key];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<array-key, mixed> $array
+     *
+     * @return array<array-key, mixed>
+     */
+    private function arrayAt(array $array, int|string ...$path): array
+    {
+        $value = $this->valueAt($array, ...$path);
+        $this->assertIsArray($value);
+
+        return $value;
+    }
+}

--- a/tests/SemanticLoggerTest.php
+++ b/tests/SemanticLoggerTest.php
@@ -589,7 +589,7 @@ final class SemanticLoggerTest extends TestCase
             $this->assertSame(1, $e->openStackDepth);
             $this->assertSame('example_event', $e->lastOperationType);
             $this->assertSame('https://example.com/schemas/example.json', $e->lastOperationSchema);
-            $this->assertStringContainsString('docs/unclosed-operations.md', $e->getMessage());
+            $this->assertStringContainsString('README.md#open--close-ordering', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

- add explicit `Strict` (default) and `Total` logger modes
- make strict writes atomic and make every flush attempt reset session state
- preserve logging topology in total mode with bundled placeholder and diagnostic schemas
- support event-only and incomplete total-mode logs in validation, schema generation, and `stree`
- repair the Null logger ID protocol, metadata validation, profiler retry behavior, and lifecycle documentation
- raise the minimum PHP version to 8.2 and keep CI coverage through PHP 8.5
- record the producing mode in the log envelope (`"mode": "strict"|"total"`) so a total-mode document with no diagnostics is self-evidently clean (optional in 0.9.x, planned required in 1.0)

## Why

The existing write path could mutate counters or the open stack before context serialization succeeded. It also allowed invalid metadata to create self-invalid documents, discarded event-only sessions, returned an empty sentinel ID from `NullSemanticLogger`, and could not represent production-safe logging failures without interrupting the host application.

These contracts ship in **0.9.0 — deliberately not 1.0**. The renderer API surface introduced alongside (`LogRendererInterface`, `LogJson::render()`, the `TreeRenderer` constructor / `renderTree()` change) was not part of the reviewed design scope, so the 1.0 freeze waits until the known consumers (BEAR.QueryRepository, be-framework, BEAR.EventSourcing) have run against this release.

## Transition contract

| Operation / condition | Strict mode | Total mode |
| --- | --- | --- |
| Any write with invalid `TYPE` or `SCHEMA_URL` | Throw a dedicated metadata exception without mutation | Record an inline core placeholder and diagnostic |
| `open` / `event` serialization failure | Rethrow without advancing the ID counter | Commit a protocol-valid placeholder and diagnostic |
| `close` with an empty stack | Throw without mutation | Record a detached diagnostic |
| `close` with a non-current ID | Throw without mutation | Record a diagnostic without popping |
| Valid `close` serialization failure | Keep the span retryable | Commit a placeholder close and pop the span |
| Sessionless `flush` | Throw, then reset | Return an idempotent `{"open":[]}` log |
| `flush` with unclosed spans | Throw, then reset | Return the live topology plus `unclosed_at_flush` |
| `flush` with diagnostics only | Not applicable | Return a valid event-only document |
| Sessionless snapshot | Throw and preserve state | Return an empty non-destructive snapshot |
| Snapshot with unclosed spans | Throw and preserve state | Synthesize a transient diagnostic without mutation |

## Breaking changes and migration impact

- Context metadata is validated at write time. Consumer types must match `^[a-z_]+$`, `semantic_logger_*` is reserved, and schema URLs must be absolute or use `./schemas/<name>.json`.
- Contexts are frozen as inert JSON trees at write time. Nested `JsonSerializable` values run once; nested JSON objects appear as `stdClass` in PHP snapshots while wire JSON is unchanged.
- Every `flush()` attempt resets session state, including strict-mode failures.
- `NullSemanticLogger::open()` now returns unique per-session `noop_N` IDs.
- PHP 8.2 is now the minimum supported version.
- The migration notes include the previously unreleased `TreeRenderer` constructor / `renderTree()` API change.
- The `stree` subpackage requires core `^0.9` — `LogRendererInterface` is new in this release, so `^0.8` cannot satisfy it.

## Validation

- `composer tests`
  - PHPCS: 74 files clean
  - PHPStan: maximum level, no errors
  - Psalm: level 1 targeting PHP 8.2, no errors
  - PHPUnit: 268 tests, 1,443 assertions, 4 skipped, 1 deprecation
- focused `DevSemanticLogger` tests pass on PHP 8.2, 8.3, 8.4, and 8.5
- bundled demo schema validation passes
- bundled diagnostic schemas parse successfully
- `git diff --check` passes

`composer cs-fix` was attempted as required, but its parallel PHPCBF run crashes inside Slevomat Coding Standard's `PropertyHelper` with an undefined `bracket_closer` key. The non-mutating PHPCS gate in `composer tests` is clean.

