### PR TITLE
Exclude timestamp from stree compact signals

### DIFF
--- a/src-stree/src/SignalExtractor.php
+++ b/src-stree/src/SignalExtractor.php
@@ -39,6 +39,7 @@ final class SignalExtractor
         'duration',
         'processingTime',
         'connectionTime',
+        'timestamp',
         'id',
         'openId',
         'schemaUrl',

--- a/src-stree/tests/SignalExtractorTest.php
+++ b/src-stree/tests/SignalExtractorTest.php
@@ -50,6 +50,7 @@ final class SignalExtractorTest extends TestCase
             'duration' => 0.3,
             'processingTime' => 0.2,
             'connectionTime' => 0.05,
+            'timestamp' => '2026-06-10T12:34:56+00:00',
             'name' => 'task',
         ];
         $result = $this->extractor->extractSignals($context);
@@ -59,6 +60,7 @@ final class SignalExtractorTest extends TestCase
         $this->assertStringNotContainsString('duration', $result);
         $this->assertStringNotContainsString('processingTime', $result);
         $this->assertStringNotContainsString('connectionTime', $result);
+        $this->assertStringNotContainsString('timestamp', $result);
         $this->assertStringContainsString('name=task', $result);
     }
 


### PR DESCRIPTION
## Summary

Fixes #39 — stree's compact rendering printed the full ISO `timestamp` on every node line. Being the longest token on each line, it dominated the view compact mode is meant to keep scannable.

## Change

- Add `timestamp` to `SignalExtractor::EXCLUDE_KEYS` (`src-stree/src/SignalExtractor.php`), alongside the other timing keys (`executionTime`, `responseTime`, ...)
- Extend `testExtractSignalsExcludesTimingKeys` to pin the exclusion

3 insertions, 0 deletions.

## Verification

- `src-stree/tests/SignalExtractorTest.php`: 29 tests / 61 assertions OK
- Full suite: 254 tests / 1,140 assertions OK, phpcs clean

🤖 Generated with [Kimi Code](https://www.moonshot.ai/)